### PR TITLE
Configure Logs with Structlog

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn jobserver.wsgi
+web: gunicorn jobserver.wsgi --config=gunicorn.conf.py

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,10 @@
+from services.logging import logging_config_dict
+
+
+# Where to log to (stdout and stderr)
+accesslog = "-"
+errorlog = "-"
+
+# Configure log structure
+# http://docs.gunicorn.org/en/stable/settings.html#logconfig-dict
+logconfig_dict = logging_config_dict

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -14,6 +14,8 @@ import os
 
 import dj_database_url
 
+from services.logging import logging_config_dict
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -54,6 +56,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_structlog.middlewares.RequestMiddleware",
 ]
 
 ROOT_URLCONF = "jobserver.urls"
@@ -143,35 +146,4 @@ REST_FRAMEWORK = {
 }
 
 # Heroku-compatible logging
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "verbose": {
-            "format": (
-                "%(asctime)s [%(process)d] [%(levelname)s] "
-                + "pathname=%(pathname)s lineno=%(lineno)s "
-                + "funcname=%(funcName)s %(message)s"
-            ),
-            "datefmt": "%Y-%m-%d %H:%M:%S",
-        },
-        "simple": {"format": "%(levelname)s %(message)s"},
-    },
-    "handlers": {
-        "null": {
-            "level": "DEBUG",
-            "class": "logging.NullHandler",
-        },
-        "console": {
-            "level": "DEBUG",
-            "class": "logging.StreamHandler",
-            "formatter": "verbose",
-        },
-    },
-    "loggers": {
-        "testlogger": {
-            "handlers": ["console"],
-            "level": "INFO",
-        }
-    },
-}
+LOGGING = logging_config_dict

--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,11 @@
-django-rest-framework
-django-filter
-gunicorn
-whitenoise
 dj-database-url
-slackclient
+django-filter
+django-rest-framework
+django-structlog
+gunicorn
 requests
+slackclient
+whitenoise
 
 # dev requirements
 black

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,8 +17,10 @@ click==7.1.2              # via black
 distlib==0.3.1            # via virtualenv
 dj-database-url==0.5.0    # via -r requirements.in
 django-filter==2.3.0      # via -r requirements.in
+django-ipware==3.0.1      # via django-structlog
 django-rest-framework==0.1.0  # via -r requirements.in
-django==3.0.7             # via django-filter, djangorestframework
+django-structlog==1.6.1   # via -r requirements.in
+django==3.0.7             # via django-filter, django-structlog, djangorestframework
 djangorestframework==3.11.0  # via django-rest-framework
 filelock==3.0.12          # via virtualenv
 flake8==3.8.3             # via -r requirements.in
@@ -38,9 +40,10 @@ pytz==2020.1              # via django
 pyyaml==5.3.1             # via pre-commit
 regex==2020.7.14          # via black
 requests==2.24.0          # via -r requirements.in
-six==1.15.0               # via virtualenv
+six==1.15.0               # via structlog, virtualenv
 slackclient==2.7.1        # via -r requirements.in
 sqlparse==0.3.1           # via django
+structlog==20.1.0         # via django-structlog
 toml==0.10.1              # via black, pre-commit
 typed-ast==1.4.1          # via black
 typing-extensions==3.7.4.3  # via black

--- a/services/logging.py
+++ b/services/logging.py
@@ -1,0 +1,85 @@
+import os
+
+import structlog
+
+
+# add logging before app has booted
+DEBUG = os.getenv("DEBUG", default=False)
+
+
+def timestamper(logger, log_method, event_dict):
+    """
+    Add timestamps to logs conditionally
+
+    Structlog provides a Timestamper processor.  However, we only want to
+    timestamp logs locally since Production stamps logs for us.  This mirrors
+    how the Timestamper processor stamps events internally.
+    """
+    if not DEBUG:
+        return event_dict
+
+    # mirror how structlogs own Timestamper calls _make_stamper
+    stamper = structlog.processors._make_stamper(fmt="iso", utc=True, key="timestamp")
+    return stamper(event_dict)
+
+
+pre_chain = [
+    # Add the log level and a timestamp to the event_dict if the log entry
+    # is not from structlog.
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.add_logger_name,
+    timestamper,
+]
+
+structlog.configure(
+    processors=[
+        structlog.stdlib.filter_by_level,
+        timestamper,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        structlog.processors.UnicodeDecoder(),
+        structlog.processors.ExceptionPrettyPrinter(),
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+    ],
+    context_class=structlog.threadlocal.wrap_dict(dict),
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger,
+    cache_logger_on_first_use=True,
+)
+
+logging_config_dict = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "formatter": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.dev.ConsoleRenderer(colors=DEBUG),
+            "foreign_pre_chain": pre_chain,
+        }
+    },
+    "handlers": {
+        "console": {
+            "level": "DEBUG",
+            "class": "logging.StreamHandler",
+            "formatter": "formatter",
+        }
+    },
+    "root": {"handlers": ["console"], "level": "WARNING"},
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
+            "propagate": False,
+        },
+        "gunicorn": {"handlers": ["console"], "level": "INFO", "propagate": False},
+        "django_structlog": {
+            "handlers": ["console"],
+            "level": "INFO",
+            "propagate": False,
+        },
+        "jobserver": {"handlers": ["console"], "level": "INFO", "propagate": False},
+    },
+}


### PR DESCRIPTION
This uses structlog to get structured logging and middleware-based request logging.  It configures gunicorn's logs to match the application's log format to make spelunking logs easier.