### PR TITLE
Job Detail Page

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.humanize",
     "rest_framework",
     "django_filters",
     "jobserver",

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% load humanize %}
+
+{% block content %}
+<ul class="list-unstyled ml-10">
+  <li class="pt-2"><strong>Status:</strong> {{ job.status }}</li>
+  <li class="pt-2">
+    <strong>Workspace:</strong> {{ job.workspace.name }}
+    <small class="text-muted">({{ job.workspace.repo }} | {{ job.workspace.branch }})</small>
+  </li>
+  <li class="pt-2"><strong>Action:</strong> {{ job.action_id|default:"-" }}</li>
+  <li class="pt-2"><strong>Created:</strong> {{ job.created_at|naturaltime }}</li>
+  <li class="pt-2"><strong>Started:</strong> {{ job.started_at|naturaltime|default_if_none:"-" }}</li>
+  <li class="pt-2"><strong>Finished:</strong> {{ job.completed_at|naturaltime|default_if_none:"-"}}</li>
+  <li class="pt-2"><strong>Status Code:</strong> {{ job.status_code }}</li>
+  <li class="pt-2"><strong>Status Message:</strong> {{ job.status_message }}</li>
+  <li class="pt-2"><strong>Needed by:</strong> {{ job.needed_by|default:"-" }}</li>
+  <li class="pt-2"><strong>Backend:</strong> {{ job.backend|default:"-" }}</li>
+  <li class="pt-2"><strong>Force run?:</strong> {{ job.force_run }}</li>
+  <li class="pt-2"><strong>Force run dependencies?:</strong> {{ job.force_run_dependencies }}</li>
+</ul>
+{% endblock content %}

--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -22,6 +22,11 @@
           <td>{{ job.pk }}</td>
           <td>{{ job.status }}</td>
           <td>{{ job.workspace.name }}</td>
+          <td>
+            <a class="btn btn-secondary text-white" href="{% url 'jobs-detail' pk=job.pk %}">
+              View
+            </a>
+          </td>
         </tr>
         {% endfor %}
 

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -19,7 +19,7 @@ from rest_framework import routers
 
 from jobserver.api import views
 
-from .views import JobList
+from .views import JobDetail, JobList
 
 
 router = routers.DefaultRouter()
@@ -28,7 +28,8 @@ router.register(r"workspaces", views.WorkspaceViewSet, "workspaces")
 
 
 urlpatterns = [
-    path("jobs/", JobList.as_view(), name="jobs"),
+    path("jobs/", JobList.as_view(), name="job-list"),
+    path("jobs/<pk>/", JobDetail.as_view(), name="job-detail"),
     path("", include(router.urls)),
     path("admin/", admin.site.urls),
     path("api-auth/", include("rest_framework.urls")),

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -1,6 +1,12 @@
-from django.views.generic import ListView
+from django.views.generic import DetailView, ListView
 
 from .api.models import Job
+
+
+class JobDetail(DetailView):
+    model = Job
+    queryset = Job.objects.select_related("workspace")
+    template_name = "job_detail.html"
 
 
 class JobList(ListView):


### PR DESCRIPTION
This adds a fairly simple Job detail page.  The ordering of the fields is fairly random since I don't know enough about them to do any sensible group just yet.  This page is likely to get some orchestration buttons later on at which point it will probably be more obvious how to group them.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/nOundzw9/Image%202020-09-24%20at%2010.16.08%20am.png?v=2839f7b51e663e4dde9b8593d65eb4ac)

Fixes #11 