### PR TITLE
Add Menu Items

### DIFF
--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -1,0 +1,26 @@
+import functools
+
+from django.urls import reverse
+
+
+def _is_active(request, prefix):
+    return request.path.startswith(prefix)
+
+
+def nav(request):
+    _active = functools.partial(_is_active, request)
+
+    options = [
+        {
+            "name": "Workspaces",
+            "is_active": _active(reverse("workspace-list")),
+            "url": reverse("workspace-list"),
+        },
+        {
+            "name": "Jobs",
+            "is_active": _active(reverse("job-list")),
+            "url": reverse("job-list"),
+        },
+    ]
+
+    return {"nav": options}

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -74,6 +74,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "jobserver.context_processors.nav",
             ],
         },
     },

--- a/jobserver/templates/base.html
+++ b/jobserver/templates/base.html
@@ -18,11 +18,24 @@
   </head>
 
   <body class="d-flex flex-column min-vh-100">
-    <header class="d-flex justify-content-between align-items-center mb-3">
-      <a class="navbar-brand mr-auto" href="/">
-        <h1 class="d-inline">OpenSAFELY Jobs</h1>
-      </a>
-    </header>
+
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
+      <a class="navbar-brand" href="/jobs">OpenSAFELY Jobs</a>
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="navbar-nav mr-auto">
+          {% for location in nav %}
+          <li class="nav-item{% if location.is_active %} active{% endif %}">
+            <a class="nav-link" href="{{ location.url }}">
+              {{ location.name }}{% if location.is_active %} <span class="sr-only">(current)</span>{% endif %}
+            </a>
+          </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </nav>
 
     <div class="container-fluid">
 


### PR DESCRIPTION
This adds menu items so one can navigate the site without knowing  URLs.  It rebuilds the menu using Bootstraps suggested layout, and uses a context processer to build the menu and its states.  I've moved to a higher contrast background (Bootstrap's primary blue) which might be a _little_ garish but we can set up a site-wide theme later.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/jkuDdlmP/Image%202020-09-24%20at%203.35.43%20pm.png?v=a8535a60f17d976a24fede997f038489)

Fixes #21 