### PR TITLE
Reorder INSTALLED_APPS

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -36,6 +36,11 @@ ALLOWED_HOSTS = ["*"]
 # Application definition
 
 INSTALLED_APPS = [
+    "jobserver",
+    "jobserver.api",
+    "crispy_forms",
+    "django_filters",
+    "rest_framework",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
@@ -43,11 +48,6 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.humanize",
-    "rest_framework",
-    "django_filters",
-    "crispy_forms",
-    "jobserver",
-    "jobserver.api",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
INSTALLED_APPS is processed top the bottom with the first app to satisfy a search used, so third party apps should go before Django apps, and the project (and its apps) should go before third party apps.

More info can be found here: http://meshy.co.uk/posts/ordering-django-applications