### PR TITLE
Set up Static in Production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,5 @@ RUN mkdir /app
 COPY . /app
 WORKDIR /app
 RUN rm -rf .python-version
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,4 @@ services:
     ports:
       - "8000:8000"
     entrypoint: /app/entrypoint.sh
+    command: /app/manage.py runserver 0.0.0.0:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,5 @@ services:
       - QUEUE_PASS=${OPENSAFELY_QUEUE_PASS}
     ports:
       - "8000:8000"
-    entrypoint: /app/entrypoint.sh
+    entrypoint: /app/entrypoint-dev.sh
     command: /app/manage.py runserver 0.0.0.0:8000

--- a/entrypoint-dev.sh
+++ b/entrypoint-dev.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+./manage.py migrate
+
+cat <<EOF | ./manage.py shell
+from django.contrib.auth import get_user_model
+
+User = get_user_model()  # get the currently active user model,
+
+User.objects.filter(username='$QUEUE_USER').exists() or \
+    User.objects.create_superuser('$QUEUE_USER', 'doesntmatter@example.com', '$QUEUE_PASS')
+EOF
+
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,5 +3,6 @@
 set -euo pipefail
 
 ./manage.py migrate
+./manage.py collectstatic --no-input
 
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,4 +13,4 @@ User.objects.filter(username='$QUEUE_USER').exists() or \
     User.objects.create_superuser('$QUEUE_USER', 'doesntmatter@example.com', '$QUEUE_PASS')
 EOF
 
-./manage.py runserver 0.0.0.0:8000
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,16 +1,7 @@
 #!/bin/bash
 
-set -e -o pipefail
+set -euo pipefail
 
 ./manage.py migrate
-
-cat <<EOF | ./manage.py shell
-from django.contrib.auth import get_user_model
-
-User = get_user_model()  # get the currently active user model,
-
-User.objects.filter(username='$QUEUE_USER').exists() or \
-    User.objects.create_superuser('$QUEUE_USER', 'doesntmatter@example.com', '$QUEUE_PASS')
-EOF
 
 exec "$@"

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -123,9 +123,6 @@ STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 STATIC_URL = "/static/"
 
-# Ensure STATIC_ROOT exists.
-os.makedirs(STATIC_ROOT, exist_ok=True)
-
 # Insert Whitenoise Middleware.
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 


### PR DESCRIPTION
This configures production to run `collectstatic` on boot.  The docker-compose-for-local-dev flow is preserved via `entrypoint-dev.sh.

Fixes #36 