### PR TITLE
Pin Python

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.direnv
+.flake8
+.github
+.pre-commit-config.yaml
+.venv
+pyproject.toml
+tests
+venv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,3 +101,10 @@ jobs:
         run: |
           source ${{ github.workspace }}/venv/bin/activate
           make test
+
+  lint-dockerfile:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: brpaz/hadolint-action@master

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,8 @@ repos:
     - id: check-toml
     - id: check-yaml
     - id: detect-private-key
+
+  - repo: https://github.com/stratasan/hadolint-pre-commit
+    rev: cdefcb0
+    hooks:
+    - id: hadolint

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,15 +7,8 @@ ENV PIP_NO_CACHE_DIR=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBCONF_NONINTERACTIVE_SEEN true
-
-RUN apt-get update
-# Required by the runner
-RUN apt-get install -y file
-RUN apt-get install -y docker.io
-
-# Copy happens twice to aid with image layers
+# Only requirements to cache them in docker layer so we can skip package
+# installation if they haven't changed
 COPY requirements.txt .
 RUN pip install --requirement requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,19 @@
-FROM ubuntu:bionic
-ARG pythonversion
+FROM python:3.8.6-slim-buster
+
+# Don't cache PyPI downloads or wheels.
+# Don't use pyc files or __pycache__ folders.
+# Don't buffer stdout/stderr output.
+ENV PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN true
 
 RUN apt-get update
-RUN apt-get -y upgrade
-# Python dependencies
-RUN apt-get install -y --no-install-recommends make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-# Pyenv dependencies
-RUN apt-get install -y ca-certificates git
 # Required by the runner
 RUN apt-get install -y file
 RUN apt-get install -y docker.io
-
-# Install pyenv
-RUN curl https://pyenv.run | bash
-ENV PATH="/root/.pyenv/shims:/root/.pyenv/bin:${PATH}"
-ENV PYENV_SHELL=bash
-
-# Install python
-RUN pyenv install $pythonversion
-RUN pyenv global $pythonversion
-
-# Install pip and requirements
-RUN curl https://bootstrap.pypa.io/get-pip.py | python
 
 # Copy happens twice to aid with image layers
 COPY requirements.txt .
@@ -33,6 +22,5 @@ RUN pip install --requirement requirements.txt
 RUN mkdir /app
 COPY . /app
 WORKDIR /app
-RUN rm -rf .python-version
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,10 @@ services:
   job-server:
     build: .
     environment:
-      - OPENSAFELY_JOB_SERVER_SECRET_KEY=${OPENSAFELY_JOB_SERVER_SECRET_KEY}
+      - OPENSAFELY_JOB_SERVER_SECRET_KEY=${OPENSAFELY_JOB_SERVER_SECRET_KEY:-12345}
       # Credentials for acessing the job server
-      - QUEUE_USER=${OPENSAFELY_QUEUE_USER}
-      - QUEUE_PASS=${OPENSAFELY_QUEUE_PASS}
+      - QUEUE_USER=${OPENSAFELY_QUEUE_USER:-queue}
+      - QUEUE_PASS=${OPENSAFELY_QUEUE_PASS:-queue}
     ports:
       - "8000:8000"
     entrypoint: /app/entrypoint-dev.sh


### PR DESCRIPTION
This pins the version of Python we run in Production (and dev via docker-compose) using a Python base image.  We gain better layer caching, fewer layers, and a simpler file by building the image this way.  This also contians changes I made to ensure the docker-compose flow works.  I've also set some options to save on image size (turning off pip caching), avoid caching edge cases (turn off pycs), and avoig buffering issues (turn off buffering).

Note: this removes, what appear to be, the unused dependencies `file` and `docker.io`.  It's been done as an atomic commit to make it easy to revert if that's incorrect.

Fixes #35 