### PR TITLE
Install and Configure Sentry

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -15,6 +15,7 @@ import dj_database_url
 from django.urls import reverse_lazy
 
 from services.logging import logging_config_dict
+from services.sentry import initialise_sentry
 
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -164,3 +165,6 @@ REST_FRAMEWORK = {
 INTERNAL_IPS = [
     "127.0.0.1",
 ]
+
+# Sentry
+initialise_sentry()

--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ django-structlog
 furl
 gunicorn
 requests
+sentry-sdk
 slackclient
 whitenoise
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ asgiref==3.2.7            # via django
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via -r requirements.in, aiohttp, pytest
 black==20.8b1             # via -r requirements.in
-certifi==2020.6.20        # via requests
+certifi==2020.6.20        # via requests, sentry-sdk
 cfgv==3.2.0               # via pre-commit
 chardet==3.0.4            # via aiohttp, requests
 click==7.1.2              # via black
@@ -59,6 +59,7 @@ pytz==2020.1              # via django
 pyyaml==5.3.1             # via pre-commit
 regex==2020.7.14          # via black
 requests==2.24.0          # via -r requirements.in
+sentry-sdk==0.17.8        # via -r requirements.in
 six==1.15.0               # via furl, orderedmultidict, packaging, python-dateutil, structlog, virtualenv
 slackclient==2.7.1        # via -r requirements.in
 sqlparse==0.3.1           # via django, django-debug-toolbar
@@ -67,7 +68,7 @@ text-unidecode==1.3       # via faker
 toml==0.10.1              # via black, pre-commit, pytest
 typed-ast==1.4.1          # via black
 typing-extensions==3.7.4.3  # via black
-urllib3==1.25.9           # via requests
+urllib3==1.25.9           # via requests, sentry-sdk
 virtualenv==20.0.31       # via pre-commit
 whitenoise==5.1.0         # via -r requirements.in
 yarl==1.4.2               # via aiohttp

--- a/services/sentry.py
+++ b/services/sentry.py
@@ -1,0 +1,29 @@
+import os
+
+import sentry_sdk
+import structlog
+from sentry_sdk.integrations.django import DjangoIntegration
+
+
+logger = structlog.get_logger(__name__)
+
+
+def initialise_sentry():
+    """
+    Initialise Sentry client
+
+    We initialise the client here so as not to pollute global settings with
+    poorly named values, ie "dsn".
+    """
+    dsn = os.getenv("SENTRY_DSN", default=None)
+    environment = os.getenv("SENTRY_ENVIRONMENT", default="localhost")
+
+    if dsn is None:
+        return
+
+    sentry_sdk.init(
+        dsn,
+        environment=environment,
+        integrations=[DjangoIntegration()],
+        send_default_pii=True,
+    )


### PR DESCRIPTION
This installs the Sentry SDK and configures it, pulling relevant config from the env.

I've pulled the configuration of Sentry itself into a function to avoid polluting the global settings with random variable names.

Fixes #41 