### PR TITLE
Paginate List Pages

### DIFF
--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -35,7 +35,7 @@
           <th scope="col">Action</th>
           <th scope="col">Description</th>
           <th scope="col">Started At</th>
-          <th scope="col">Elpased Time</th>
+          <th scope="col">Elapsed Time</th>
           <th scope="col"></th>
         </tr>
       </thead>

--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -74,6 +74,33 @@
 
     <hr />
 
+    <div class="d-flex justify-content-between mb-3">
+
+      <div>
+        <span class="{% if not page_obj.has_previous %}d-none{% endif %}">
+          {% if page_obj.has_previous %}
+          <a class="btn btn-secondary btn-sm" href="{% url_with_querystring page=page_obj.previous_page_number %}">
+            Previous
+          </a>
+          {% endif %}
+        </span>
+      </div>
+
+      <div class="current">
+        Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+      </div>
+
+      <div>
+        <span class="{% if not page_obj.has_next %}d-none{% endif %}">
+          {% if page_obj.has_next %}
+          <a class="btn btn-secondary btn-sm" href="{% url_with_querystring page=page_obj.next_page_number %}">
+            Next
+          </a>
+          {% endif %}
+        </span>
+      </div>
+
+    </div>
   </div>
 
   <div class="col-2 filters">

--- a/jobserver/templates/workspace_list.html
+++ b/jobserver/templates/workspace_list.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% load querystring_tools %}
+
 {% block content %}
 
 <div class="d-flex justify-content-between mt-3 mb-4">
@@ -49,6 +51,33 @@
 
     <hr />
 
+    <div class="d-flex justify-content-between mb-3">
+
+      <div>
+        <span class="{% if not page_obj.has_previous %}d-none{% endif %}">
+          {% if page_obj.has_previous %}
+          <a class="btn btn-secondary btn-sm" href="{% url_with_querystring page=page_obj.previous_page_number %}">
+            Previous
+          </a>
+          {% endif %}
+        </span>
+      </div>
+
+      <div class="current">
+        Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+      </div>
+
+      <div>
+        <span class="{% if not page_obj.has_next %}d-none{% endif %}">
+          {% if page_obj.has_next %}
+          <a class="btn btn-secondary btn-sm" href="{% url_with_querystring page=page_obj.next_page_number %}">
+            Next
+          </a>
+          {% endif %}
+        </span>
+      </div>
+
+    </div>
   </div>
 
   <div class="col-2">

--- a/jobserver/templatetags/querystring_tools.py
+++ b/jobserver/templatetags/querystring_tools.py
@@ -12,12 +12,21 @@ def url_with_querystring(context, **kwargs):
 
     Takes context so we can get the request to get the current URL with its
     existing query params.  Then we update those with any kwargs passed in.
+
+    We need to handle pagination as a bit of an edge case.  We don't want to
+    blindly apply filters since a user could easily get no results due to
+    pagination.  Instead we remove the page arg only when a new filter is added
+    to the URL.
     """
     request = context["request"]
     f = furl(request.get_full_path())
 
     for k, v in kwargs.items():
         f.args[k] = v
+
+    # avoid deleting page when it's explicitly in kwargs
+    if "page" not in kwargs and "page" in f.args:
+        del f.args["page"]
 
     return f.url
 
@@ -29,11 +38,17 @@ def url_without_querystring(context, **kwargs):
 
     Takes context so we can get the request to get the current URL with its
     existing query params.  Then we update those with any kwargs passed in.
+
+    We also blindly remove the page argument since we want to wipe the current
+    page whenever removing a filter.
     """
     request = context["request"]
     f = furl(request.get_full_path())
 
     for k in kwargs.keys():
         del f.args[k]
+
+    if "page" in f.args:
+        del f.args["page"]
 
     return f.url

--- a/tests/jobserver/templatetags/test_querystring_tools.py
+++ b/tests/jobserver/templatetags/test_querystring_tools.py
@@ -1,0 +1,82 @@
+# add foo=bar when page=N
+# add foo=bar when page is not set
+# remove foo=bar when page=N
+# remove foo=bar when page is not set
+from jobserver.templatetags.querystring_tools import (
+    url_with_querystring,
+    url_without_querystring,
+)
+
+
+def test_url_with_querystring_setting_other_arg_set_with_no_page(rf):
+    context = {"request": rf.get("/")}
+
+    output = url_with_querystring(context, foo="bar")
+
+    assert output == "/?foo=bar"
+
+
+def test_url_with_querystring_setting_other_arg_when_page_equals_2(rf):
+    """
+    Test {% url_with_querystring foo=bar %} when the URL contains ?page=2
+
+    We want the _addition_ of a filter query arg to the URL to remove any page
+    argument
+    """
+    context = {"request": rf.get("/?page=2")}
+
+    output = url_with_querystring(context, foo="bar")
+
+    assert output == "/?foo=bar"
+
+
+def test_url_with_querystring_updating_other_arg_set_and_page_equals_2(rf):
+    """
+    Test {% url_with_querystring foo=bar %} when the URL contains ?page=2
+
+    We want the _addition_ of a filter query arg to the URL to remove any page
+    argument
+    """
+    context = {"request": rf.get("/?page=2&foo=test")}
+
+    output = url_with_querystring(context, foo="bar")
+
+    assert output == "/?foo=bar"
+
+
+def test_url_with_querystring_setting_page(rf):
+    context = {"request": rf.get("/")}
+
+    output = url_with_querystring(context, page="3")
+
+    assert output == "/?page=3"
+
+
+def test_url_with_querystring_updating_page(rf):
+    context = {"request": rf.get("/?page=2")}
+
+    output = url_with_querystring(context, page="3")
+
+    assert output == "/?page=3"
+
+
+def test_url_without_querystring_setting_other_arg_set_with_no_page(rf):
+    context = {"request": rf.get("/?foo=bar")}
+
+    output = url_without_querystring(context, foo="bar")
+
+    assert output == "/"
+
+
+def test_url_without_querystring_setting_other_arg_when_page_equals_2(rf):
+    """
+    Test {% url_without_querystring foo=bar %} when the URL contains ?page=2
+
+    We want the _addition_ of a filter query arg to the URL to remove any page
+    argument
+    """
+    context = {"request": rf.get("/?foo=bar&page=2")}
+
+    output = url_without_querystring(context, foo="bar")
+
+    assert output == "/"


### PR DESCRIPTION
This adds pagination to the Job and Workspace list pages.
 
Since we use query args for filtering (via the `url_with[out]_querystring` templatetags) and Pagination also makes use of them I needed to make the templatetags aware of the `page` argument.  This addresses adding/removing a filter while on a page greater than one.  Either use case can result in an erroneously empty page.  Instead I've opted to reset the page arg whenenver a filter is changed.  Note: pagination while using a filter still works as expected.

Fixes #13 