### PR TITLE
Fix Login

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -138,6 +138,7 @@ LOGGING = logging_config_dict
 # Auth
 LOGIN_REDIRECT_URL = reverse_lazy("workspace-list")
 LOGOUT_REDIRECT_URL = "/"
+LOGIN_URL = reverse_lazy("login")
 
 
 # THIRD PARTY SETTINGS

--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -9,11 +9,13 @@
 
   <h2>Jobs</h2>
 
+  {% if user.is_authenticated %}
   <div>
     <a class="btn btn-primary" href="{% url 'job-create' %}">
       Add Job
     </a>
   </div>
+  {% endif %}
 
 </div>
 

--- a/jobserver/templates/workspace_list.html
+++ b/jobserver/templates/workspace_list.html
@@ -6,11 +6,13 @@
 
   <h2>Workspaces</h2>
 
+  {% if user.is_authenticated %}
   <div>
     <a class="btn btn-primary" href="{% url 'workspace-create' %}">
       Add Workspace
     </a>
   </div>
+  {% endif %}
 
 </div>
 


### PR DESCRIPTION
This hides the Add Job and Add Workspace buttons from their respective list pages.  It also configures the LOGIN_URL setting to point to our Login view (instead of the default `/accounts/login`) since I discovered that while fixing the previous bug.