### PR TITLE
Order Workspaces

### DIFF
--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -80,6 +80,7 @@ class WorkspaceDetail(DetailView):
 
 
 class WorkspaceList(ListView):
+    ordering = "name"
     paginate_by = 25
     queryset = Workspace.objects.prefetch_related("jobs")
     template_name = "workspace_list.html"


### PR DESCRIPTION
This sets an ordering for the Workspace list page.  We don't have many workspaces yet and I've only had 4-5 in testing so this was easy to miss.  Luckily Django's [default Paginator](https://github.com/django/django/blob/3.0.7/django/core/paginator.py#L110-L126) warns about this and pytest picks that up by default 🎉