### PR TITLE
Job List Fixes

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -112,6 +112,9 @@ class Job(models.Model):
             if self.status_code == 7:
                 return "Dependency Failed"
 
+            if self.status_code == 8:
+                return "Pending"
+
             return "Failed"
 
         if self.started_at and not self.completed_at:

--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -56,7 +56,7 @@
             {% if job.runtime.seconds %}{{ job.runtime.seconds }} second(s){% endif %}
           </td>
           <td>
-            <a class="btn btn-secondary text-white" href="{% url 'jobs-detail' pk=job.pk %}">
+            <a class="btn btn-secondary text-white" href="{{ job.get_absolute_url }}">
               View
             </a>
           </td>

--- a/jobserver/templatetags/status_tools.py
+++ b/jobserver/templatetags/status_tools.py
@@ -44,7 +44,7 @@ def status_icon(status_name):
 
     # Wrap to the SVG so we can style it neatly
     icon = f"""
-    <div style="color:{status['color']};width:1rem;">
+    <div style="color:{status['color']};width:1rem;" title="{status_name}">
         {svg}
     </div>
     """


### PR DESCRIPTION
This fixes a few small parts of the Job List:

* View button goes to the correct Job detail page now
* Hovering over a status icon shows the Status label (via `title`)
* Convert `DependencyRunning` -> `Pending`

Fixes #63 
Fixes #66 