### PR TITLE
Add search to Job list page

### DIFF
--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -13,10 +13,24 @@
   <h2>Jobs</h2>
 
   {% if user.is_authenticated %}
-  <div>
-    <a class="btn btn-primary" href="{% url 'job-create' %}">
-      Add Job
-    </a>
+  <div class="d-flex align-items-center">
+
+    <form class="form-inline mr-3" method="GET">
+      <input
+        class="form-control mr-sm-2"
+        type="search"
+        placeholder="Search action_id or job_id"
+        aria-label="Search"
+        name="q" />
+      <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
+    </form>
+
+    <div>
+      <a class="btn btn-primary" href="{% url 'job-create' %}">
+        Add Job
+      </a>
+    </div>
+
   </div>
   {% endif %}
 

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import LoginView
+from django.db.models import Q
 from django.shortcuts import redirect
 from django.utils.decorators import method_decorator
 from django.views.generic import CreateView, DetailView, ListView
@@ -38,6 +39,17 @@ class JobList(ListView):
 
     def get_queryset(self):
         qs = super().get_queryset().select_related("workspace")
+
+        q = self.request.GET.get("q")
+        if q:
+            try:
+                q = int(q)
+            except ValueError:
+                qs = qs.filter(action_id__icontains=q)
+            else:
+                # if the query looks enough like a number for int() to handle
+                # it then we can look for a job number
+                qs = qs.filter(Q(action_id__icontains=q) | Q(pk=q))
 
         status = self.request.GET.get("status")
         if status:

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -74,6 +74,30 @@ def test_joblist_filter_by_workspace(rf):
     assert len(response.context_data["object_list"]) == 1
 
 
+@pytest.mark.django_db
+def test_joblist_search_by_action(rf):
+    job1 = JobFactory(action_id="run")
+    JobFactory(action_id="leap")
+
+    request = rf.get("/?q=run")
+    response = JobList.as_view()(request)
+
+    assert len(response.context_data["object_list"]) == 1
+    assert response.context_data["object_list"][0] == job1
+
+
+@pytest.mark.django_db
+def test_joblist_search_by_id(rf):
+    JobFactory()
+    job2 = JobFactory(id=99)
+
+    request = rf.get("/?q=99")
+    response = JobList.as_view()(request)
+
+    assert len(response.context_data["object_list"]) == 1
+    assert response.context_data["object_list"][0] == job2
+
+
 def test_login(rf):
     request = rf.get("/")
     response = Login.as_view()(request)


### PR DESCRIPTION
This adds a search box to the Job list page:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/geuqZB6x/Image%202020-10-02%20at%2011.16.13%20am.png?v=280dd9e7c920468b1be0aacddefe1e91)

Behind the scenes it's searching for either action and ID or just action (if we can't convert the query to an int).

Fixes #69 