### PR TITLE
Push filters below list on smaller viewports

### DIFF
--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -24,7 +24,7 @@
 
 <div class="row">
 
-  <div class="col-10">
+  <div class="col-md-10">
 
     <table class="table table-hover">
       <thead>
@@ -103,7 +103,7 @@
     </div>
   </div>
 
-  <div class="col-2 filters">
+  <div class="col-md-2 filters">
     <h4>Filters</h4>
 
     <h5>Status</h5>


### PR DESCRIPTION
This moves the Job list page's two-column layout to Bootstrap's [`md`](https://getbootstrap.com/docs/4.0/layout/grid/#grid-options) column sizes.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/JrugvEpg/Image%202020-10-02%20at%2011.49.33%20am.png?v=4e8dcf7ffa939a6260a793b6e814ab2f)

The Job list itself still needs more work since it overflows the screen but elements are no longer overlapping so this is a start.

Fixes #64 