### PR TITLE
Remove expandability of JobRequest when it has no jobs

### DIFF
--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -74,16 +74,21 @@
           <div class="mx-2">
             <button
               class="btn btn-sm btn-primary"
+              {% if not group.jobs.exists %}
+              disabled
+              {% endif %}
               type="button"
               data-toggle="collapse"
               data-target="#group-{{ group.pk }}"
               aria-expanded="false"
-              aria-controls="group-{{ group.pk }}">
+              aria-controls="group-{{ group.pk }}"
+              >
               Show/Hide Individual Jobs
             </button>
           </div>
         </div>
 
+        {% if group.jobs.exists %}
         <div id="group-{{ group.pk }}" class="collapse">
           <ul class="list-unstyled ml-3 border-top" style="border-left: 2px solid grey">
             <li class="d-flex py-2 border-top">
@@ -122,6 +127,7 @@
             {% endfor %}
           </ul>
         </div>
+        {% endif %}
 
       </div>
       {% endfor %}


### PR DESCRIPTION
This fixes a small bug with the Jobs list view where a JobRequest with no Jobs still had a working show/hide button which opened an empty list of Jobs.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/bLuwjOPe/Image%202020-10-09%20at%203.52.43%20pm.png?v=1471980e19e9d282ff009217fe1b222f)