### PR TITLE
Prod Fixes

### DIFF
--- a/jobserver/serializers.py
+++ b/jobserver/serializers.py
@@ -42,7 +42,7 @@ class JobShimSerializer(serializers.Serializer):
 
     url = serializers.HyperlinkedIdentityField(view_name="jobs-detail")
     pk = serializers.IntegerField(read_only=True)
-    backend = serializers.CharField(source="job_request.backend")
+    backend = serializers.CharField(source="job_request.backend", default="")
     started = serializers.BooleanField(default=False)
     force_run = serializers.BooleanField(default=False)
     force_run_dependencies = serializers.BooleanField(
@@ -53,7 +53,9 @@ class JobShimSerializer(serializers.Serializer):
     status_message = serializers.CharField(allow_null=True, required=False)
     outputs = JobOutputSerializer(many=True, required=False)
     needed_by_id = serializers.IntegerField(allow_null=True)
-    workspace = WorkspaceSerializer(read_only=True, source="job_request.workspace")
+    workspace = WorkspaceSerializer(
+        read_only=True, source="job_request.workspace", default=""
+    )
     workspace_id = serializers.IntegerField(
         source="job_request.workspace_id", required=False
     )

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -7,8 +7,12 @@
   <li class="pt-2"><strong>Status:</strong> {{ job.status }}</li>
   <li class="pt-2">
     <strong>Workspace:</strong>
-    <a href={% url 'workspace-detail' pk=job.workspace.pk %}>{{ job.workspace.name }}</a>
-    <small class="text-muted">({{ job.workspace.repo }} | {{ job.workspace.branch }})</small>
+    <a href={% url 'workspace-detail' pk=job.job_request.workspace.pk %}>
+      {{ job.job_request.workspace.name }}
+    </a>
+    <small class="text-muted">
+      ({{ job.job_request.workspace.repo }} | {{ job.job_request.workspace.branch }})
+    </small>
   </li>
   <li class="pt-2"><strong>Action:</strong> {{ job.action_id|default:"-" }}</li>
   <li class="pt-2"><strong>Created:</strong> {{ job.created_at|naturaltime }}</li>


### PR DESCRIPTION
This aims to address the two most obvious production failures:
* The APIs list & detail pages breaking for pre-`JobRequest` Jobs (because we had no default for the serializer trying to source `job.job_request.backend`)
* Job Detail pages trying to reverse the Workspace Detail URL with a broken variable.