### PR TITLE
Make workspace API Key Optional

### DIFF
--- a/jobserver/serializers.py
+++ b/jobserver/serializers.py
@@ -53,9 +53,7 @@ class JobShimSerializer(serializers.Serializer):
     status_message = serializers.CharField(allow_null=True, required=False)
     outputs = JobOutputSerializer(many=True, required=False)
     needed_by_id = serializers.IntegerField(allow_null=True)
-    workspace = WorkspaceSerializer(
-        read_only=True, source="job_request.workspace", default=""
-    )
+    workspace = WorkspaceSerializer(read_only=True, source="job_request.workspace")
     workspace_id = serializers.IntegerField(
         source="job_request.workspace_id", required=False
     )


### PR DESCRIPTION
This removes the `default` option to the `workspace` key in the Jobs API.

For `Job`s with no `JobRequest` this results in the removal of their `workspace` key, however I don't think this should be an issue as they're now legacy `Job`s.

With the previous default of an empty string we got errors because DRF took that when building the `workspace` key for those legacy `Job`s and tried to look up various values on the empty string.