### PR TITLE
Grid Job List

### DIFF
--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -2,6 +2,7 @@
 
 {% load humanize %}
 {% load querystring_tools %}
+{% load runtime %}
 {% load selected_filter %}
 {% load static %}
 {% load status_tools %}
@@ -65,12 +66,7 @@
               {{ group.requested_action }}
             </div>
             <div class="started-at">{{ group.started_at|naturaltime|default_if_none:"-" }}</div>
-            <div class="runtime">
-              {% if not group.runtime %}-{% endif %}
-              {% if group.runtime.hours %}{{ group.runtime.hours }} hour(s){% endif %}
-              {% if group.runtime.minutes %}{{ group.runtime.minutes }} minute(s){% endif %}
-              {% if group.runtime.seconds %}{{ group.runtime.seconds }} second(s){% endif %}{% runtime group.runtime %}
-            </div>
+            <div class="runtime">{% runtime group.runtime %}</div>
             <div class="mx-2">
               <button
                 class="btn btn-sm btn-primary"
@@ -103,10 +99,7 @@
               <span class="d-none d-lg-inline"><small>{{ job.pk }}</small></span>
               <span>{{ job.action_id }}</span>
               <span {% if job.started_at %} title="{{ job.started_at|naturaltime }}"{% endif %}>
-                {% if not job.runtime %}-{% endif %}
-                {% if job.runtime.hours %}{{ job.runtime.hours }} hour(s){% endif %}
-                {% if job.runtime.minutes %}{{ job.runtime.minutes }} minute(s){% endif %}
-                {% if job.runtime.seconds %}{{ job.runtime.seconds }} second(s){% endif %}
+                <small>{% runtime job.runtime %}</small>
               </span>
               <span class="d-none d-lg-inline text-truncate" title="{{ job.status_message }}">
                 {{ job.status_message|default:"-" }}

--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -45,92 +45,87 @@
       </div>
       {% else %}
 
-      <div class="d-flex headers">
-        <div class="status"></div>
-        <div class="workspace"><strong>Workspace</strong></div>
-        <div class="jobs"><strong>Jobs</strong></div>
-        <div class="action"><strong>Requested Action</strong></div>
-        <div class="started-at"><strong>Started</strong></div>
-        <div class="runtime"><strong>Runtime</strong></div>
-      </div>
-
-      {% for group in object_list %}
-      <div class="job-request">
-
-        <div class="d-flex align-items-center py-2">
-          <div class="status">{% status_icon group.status %}</div>
-          <div class="workspace">{{ group.workspace.name }}</div>
-          <div class="jobs">{{ group.num_completed }}/{{ group.jobs.all|length }}</div>
-          <div class="action text-truncate" title="group.requested_action">
-            {{ group.requested_action }}
-          </div>
-          <div class="started-at">{{ group.started_at|naturaltime|default_if_none:"-" }}</div>
-          <div class="runtime">
-            {% if not group.runtime %}-{% endif %}
-            {% if group.runtime.hours %}{{ group.runtime.hours }} hour(s){% endif %}
-            {% if group.runtime.minutes %}{{ group.runtime.minutes }} minute(s){% endif %}
-            {% if group.runtime.seconds %}{{ group.runtime.seconds }} second(s){% endif %}
-          </div>
-          <div class="mx-2">
-            <button
-              class="btn btn-sm btn-primary"
-              {% if not group.jobs.exists %}
-              disabled
-              {% endif %}
-              type="button"
-              data-toggle="collapse"
-              data-target="#group-{{ group.pk }}"
-              aria-expanded="false"
-              aria-controls="group-{{ group.pk }}"
-              >
-              Show/Hide Individual Jobs
-            </button>
-          </div>
+      <div class="job-requests">
+        <div class="d-flex">
+          <div class="status"></div>
+          <div class="workspace"><strong>Workspace</strong></div>
+          <div class="job-count"><strong>Jobs</strong></div>
+          <div class="action"><strong>Requested Action</strong></div>
+          <div class="started-at"><strong>Started</strong></div>
+          <div class="runtime"><strong>Runtime</strong></div>
         </div>
 
-        {% if group.jobs.exists %}
-        <div id="group-{{ group.pk }}" class="collapse">
-          <ul class="list-unstyled ml-3 border-top" style="border-left: 2px solid grey">
-            <li class="d-flex py-2 border-top">
-              <div style="width:48px"></div>
-              <div class="mr-2" style="min-width:25px"><strong>ID</strong></div>
-              <div class="mr-2" style="min-width:80px"><strong>Action</strong></div>
-              <div class="mr-3" style="min-width:200px"><strong>Runtime</strong></div>
-              <div><strong>Status Message</strong></div>
-            </li>
-            {% for job in group.ordered_jobs %}
-            <li class="d-flex py-2 border-top">
-              <div class="mx-3">{% status_icon job.status %}</div>
-              <div class="mr-2" style="min-width:25px">{{ job.pk }}</div>
-              <div class="mr-2" style="min-width:80px">{{ job.action_id }}</div>
-              <div
-                class="mr-3 text-nowrap"
-                {% if job.started_at %}
-                title="{{ job.started_at|naturaltime }}"
+        {% for group in object_list %}
+        <div class="job-request">
+          <div class="d-flex align-items-center py-2">
+            <div class="status">{% status_icon group.status %}</div>
+            <div class="workspace">{{ group.workspace.name }}</div>
+            <div class="job-count">{{ group.num_completed }}/{{ group.jobs.all|length }}</div>
+            <div class="action text-truncate" title="group.requested_action">
+              {{ group.requested_action }}
+            </div>
+            <div class="started-at">{{ group.started_at|naturaltime|default_if_none:"-" }}</div>
+            <div class="runtime">
+              {% if not group.runtime %}-{% endif %}
+              {% if group.runtime.hours %}{{ group.runtime.hours }} hour(s){% endif %}
+              {% if group.runtime.minutes %}{{ group.runtime.minutes }} minute(s){% endif %}
+              {% if group.runtime.seconds %}{{ group.runtime.seconds }} second(s){% endif %}{% runtime group.runtime %}
+            </div>
+            <div class="mx-2">
+              <button
+                class="btn btn-sm btn-primary"
+                {% if not group.jobs.exists %}
+                disabled
                 {% endif %}
-                style="min-width:200px"
+                type="button"
+                data-toggle="collapse"
+                data-target="#group-{{ group.pk }}"
+                aria-expanded="false"
+                aria-controls="group-{{ group.pk }}"
                 >
+                Show/Hide Individual Jobs
+              </button>
+            </div>
+          </div>
+
+          {% if group.jobs.exists %}
+          <div id="group-{{ group.pk }}" class="jobs collapse">
+            <div class="grid">
+              <span class="pl-3"></span>
+              <span class="d-none d-lg-inline"><strong>ID</strong></span>
+              <span><strong>Action</strong></span>
+              <span><strong>Runtime</strong></span>
+              <span class="d-none d-lg-inline"><strong>Status Message</strong></span>
+              <span></span>
+
+              {% for job in group.ordered_jobs %}
+              <span class="pl-3">{% status_icon job.status %}</span>
+              <span class="d-none d-lg-inline"><small>{{ job.pk }}</small></span>
+              <span>{{ job.action_id }}</span>
+              <span {% if job.started_at %} title="{{ job.started_at|naturaltime }}"{% endif %}>
                 {% if not job.runtime %}-{% endif %}
                 {% if job.runtime.hours %}{{ job.runtime.hours }} hour(s){% endif %}
                 {% if job.runtime.minutes %}{{ job.runtime.minutes }} minute(s){% endif %}
                 {% if job.runtime.seconds %}{{ job.runtime.seconds }} second(s){% endif %}
-              </div>
-              <div class="mr-2 flex-grow-1 text-truncate"{% if job.status_message %} title="{{ job.status_message }}"{% endif %}>
+              </span>
+              <span class="d-none d-lg-inline text-truncate" title="{{ job.status_message }}">
                 {{ job.status_message|default:"-" }}
-              </div>
-              <div class="mx-2">
+              </span>
+              <span>
                 <a class="btn btn-sm btn-secondary text-white" href="{% url 'jobs-detail' pk=job.pk %}">
                   View
                 </a>
-              </div>
-            </li>
-            {% endfor %}
-          </ul>
+              </span>
+              {% endfor %}
+            </div>
+
+          </div>
+          {% endif %}
+
         </div>
-        {% endif %}
+        {% endfor %}  {# end of object_list loop #}
 
       </div>
-      {% endfor %}
 
       <div class="d-flex justify-content-between my-3">
 

--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -26,7 +26,7 @@
 
   <div class="row">
 
-    <div class="col-md-10">
+    <div class="col-lg-10">
 
     <form class="form d-flex align-items-center mb-4" method="GET">
       <input
@@ -150,7 +150,7 @@
       {% endif %}
     </div>
 
-    <div class="col-md-2 filters">
+    <div class="col-lg-2 filters">
       <h4>Filters</h4>
 
       {% if request.GET %}

--- a/jobserver/templatetags/runtime.py
+++ b/jobserver/templatetags/runtime.py
@@ -1,0 +1,14 @@
+from django import template
+
+from ..runtime import Runtime
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def runtime(r: Runtime):
+    if not r:
+        return "-"
+
+    return f"{r.hours:02d}:{r.minutes:02d}:{r.seconds:02d}"

--- a/jobserver/templatetags/status_tools.py
+++ b/jobserver/templatetags/status_tools.py
@@ -48,7 +48,7 @@ def status_icon(status_name):
 
     # Wrap to the SVG so we can style it neatly
     icon = f"""
-    <div {spinner} style="color:{status['color']};width:1rem;" title="{status_name}">
+    <div {spinner} style="color:{status['color']};width:16px;" title="{status_name}">
         {svg}
     </div>
     """

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -8,34 +8,28 @@ header {
 .job-list .job-request:nth-child(2) {
   border-top: 2px solid #dee2e6;
 }
-.job-list .headers .status,
-.job-list .job-request .status {
+.job-list .job-requests .status {
   margin-left: .5rem;
   margin-right: 1rem;
   width: 16px;
 }
-.job-list .headers .workspace,
-.job-list .job-request .workspace {
+.job-list .job-requests .workspace {
   margin-right: .5rem;
   width: 10%;
 }
-.job-list .headers .jobs,
-.job-list .job-request .jobs {
+.job-list .job-requests .job-count {
   margin-right: .5rem;
   width: 5%;
 }
-.job-list .headers .action,
-.job-list .job-request .action {
+.job-list .job-requests .action {
   margin-right: .5rem;
   width: 15%;
 }
-.job-list .headers .started-at,
-.job-list .job-request .started-at {
+.job-list .job-requests .started-at {
   margin-right: .5rem;
   width: 20%;
 }
-.job-list .headers .runtime,
-.job-list .job-request .runtime {
+.job-list .job-requests .runtime {
   margin-right: .5rem;
   min-width: 206px;
   flex-grow: 1;
@@ -50,6 +44,31 @@ header {
   100% {
     transform: rotate(360deg);
   }
+}
+
+.job-list .jobs .grid {
+  display: grid;
+  grid-template-columns: min-content min-content minmax(min-content, 80px) min-content;
+  align-items: center;
+  border-left: 2px solid grey;
+  border-top: 1px solid #dee2e6;
+  margin-bottom: 1rem;
+  margin-left: 1rem;
+}
+/* Add the ID and Status message columns for larger devices (992px and up) */
+@media (min-width: 992px) {
+  .job-list .jobs .grid {
+    grid-template-columns: min-content min-content min-content minmax(min-content, 80px) 3fr min-content;
+  }
+}
+
+/*
+ * Set a consistent top&bottom padding for Job cells.
+ * Use right padding to add horizontal space between cells.
+ * Status icon (the first cell) sets its own left padding.
+ */
+.job-list .jobs .grid > span {
+  padding: .25rem 1rem .25rem 0;
 }
 
 


### PR DESCRIPTION
This rebuilds the per-JobRequest list of Jobs using CSS grid so we can get table-like functionality without the problems using `<table>` brings (namely fixed-width tables force equal-width columns).  It also drops some columns on smaller devices to make the UI more readable there.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/geuqAzQX/Image%202020-10-19%20at%2012.16.15%20pm.png?v=7802e6383d8a31e2bf3d6bd081b85e3a)

![](https://p198.p4.n0.cdn.getcloudapp.com/items/z8uYrZ0O/Image%202020-10-19%20at%2012.20.07%20pm.png?v=f724eae2cae259523c0ae6850b96ed30)

The JobRequest data is still not great on phone sized screens (small/medium in Bootstrap terms):

![](https://p198.p4.n0.cdn.getcloudapp.com/items/nOunvk0N/Image%202020-10-19%20at%2012.21.13%20pm.png?v=5fc2b42fb1b98a81db70417e377d2b16)

But I need to have a think on how to make that more responsive since I can't apply a normal Grid to it.