### PR TITLE
Add User Dashboard

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -142,7 +142,7 @@ AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
 ]
 AUTH_USER_MODEL = "jobserver.User"
-LOGIN_REDIRECT_URL = reverse_lazy("workspace-list")
+LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 LOGIN_URL = reverse_lazy("social:begin", kwargs={"backend": "github"})
 SOCIAL_AUTH_GITHUB_KEY = os.getenv("SOCIAL_AUTH_GITHUB_KEY")

--- a/jobserver/templates/base.html
+++ b/jobserver/templates/base.html
@@ -21,7 +21,7 @@
 
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary mb-4">
 
-      <a class="navbar-brand" href="/jobs">OpenSAFELY Jobs</a>
+      <a class="navbar-brand" href="/">OpenSAFELY Jobs</a>
 
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>

--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -184,6 +184,7 @@
         {% endfor %}
       </ul>
 
+      {% if users %}
       <h5>User</h5>
       <ul class="list-group list-unstyled mb-4 users">
         {% for username, name in users.items %}
@@ -208,6 +209,7 @@
         </li>
         {% endfor %}
       </ul>
+      {% endif %}
 
       <h5>Workspaces</h5>
       <ul class="list-group list-unstyled">

--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -163,9 +163,11 @@
       <ul class="list-group list-unstyled mb-4">
         {% for status in statuses %}
         {% is_filter_selected key="status" value=status as is_active %}
-        <li class="list-group-item {% if is_active %} active{% endif %}">
+        <li class="list-group-item d-flex {% if is_active %} active{% endif %}">
 
-          <a href="{% url_with_querystring status=status %}">{{ status }}</a>
+          <a class="text-truncate flex-grow-1" href="{% url_with_querystring status=status %}">
+            {{ status }}
+          </a>
 
           {% if is_active %}
           <a
@@ -186,9 +188,11 @@
       <ul class="list-group list-unstyled mb-4 users">
         {% for username, name in users.items %}
         {% is_filter_selected key="username" value=username as is_active %}
-        <li class="list-group-item{% if is_active %} active{% endif %}">
+        <li class="list-group-item d-flex{% if is_active %} active{% endif %}">
 
-          <a href="{% url_with_querystring username=username %}">{{ name }}</a>
+          <a class="text-truncate flex-grow-1" href="{% url_with_querystring username=username %}">
+            {{ name }}
+          </a>
 
           {% if is_active %}
           <a
@@ -209,9 +213,11 @@
       <ul class="list-group list-unstyled">
         {% for workspace in workspaces %}
         {% is_filter_selected key="workspace" value=workspace.pk as is_active %}
-        <li class="list-group-item list-group-item-action{% if is_active %} active{% endif %}">
+        <li class="list-group-item d-flex{% if is_active %} active{% endif %}">
 
-          <a href="{% url_with_querystring workspace=workspace.pk %}">{{ workspace.name }}</a>
+          <a class="text-truncate flex-grow-1" href="{% url_with_querystring workspace=workspace.pk %}">
+            {{ workspace.name }}
+          </a>
 
           {% if is_active %}
           <a

--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -182,6 +182,29 @@
         {% endfor %}
       </ul>
 
+      <h5>User</h5>
+      <ul class="list-group list-unstyled mb-4 users">
+        {% for username, name in users.items %}
+        {% is_filter_selected key="username" value=username as is_active %}
+        <li class="list-group-item{% if is_active %} active{% endif %}">
+
+          <a href="{% url_with_querystring username=username %}">{{ name }}</a>
+
+          {% if is_active %}
+          <a
+            type="button"
+            class="close"
+            aria-label="Close"
+            href="{% url_without_querystring username=username %}"
+            >
+            <span aria-hidden="true">&times;</span>
+          </a>
+          {% endif %}
+
+        </li>
+        {% endfor %}
+      </ul>
+
       <h5>Workspaces</h5>
       <ul class="list-group list-unstyled">
         {% for workspace in workspaces %}

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -16,14 +16,14 @@ Including another URLconf
 import debug_toolbar
 from django.contrib.auth.views import LogoutView
 from django.urls import include, path
-from django.views.generic import RedirectView
 from rest_framework import routers
 
 from .api import JobViewSet, WorkspaceViewSet
 from .views import (
+    Dashboard,
     JobDetail,
-    JobList,
     JobRequestCreate,
+    JobRequestList,
     WorkspaceCreate,
     WorkspaceDetail,
     WorkspaceList,
@@ -37,11 +37,11 @@ router.register(r"workspaces", WorkspaceViewSet, "workspaces")
 
 
 urlpatterns = [
-    path("", RedirectView.as_view(pattern_name="job-list")),
+    path("", Dashboard.as_view()),
     path("", include("social_django.urls", namespace="social")),
     path("api/", include(router.urls)),
     path("api-auth/", include("rest_framework.urls")),
-    path("jobs/", JobList.as_view(), name="job-list"),
+    path("jobs/", JobRequestList.as_view(), name="job-list"),
     path("jobs/new/", WorkspaceSelectOrCreate.as_view(), name="job-select-workspace"),
     path("jobs/new/<pk>/", JobRequestCreate.as_view(), name="job-create"),
     path("jobs/<pk>/", JobDetail.as_view(), name="job-detail"),

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -10,42 +10,97 @@ from .forms import JobRequestCreateForm, WorkspaceCreateForm
 from .models import Job, JobRequest, User, Workspace
 
 
+def filter_by_status(job_requests, status):
+    """
+    Filter JobRequests by possible status
+
+    Status is currently inferred from various Job fields and "bubbled up"
+    to a JobRequest.  This converts the view's QuerySet to a list via a
+    filter which uses properties on JobRequest to cut down the values to
+    those requested.
+
+    TODO: replace with a custom QuerySet once status is driven entirely via
+    the job-runner
+    """
+    if not status:
+        return job_requests
+
+    status_lut = {
+        "completed": lambda r: r.is_complete,
+        "failed": lambda r: r.is_failed,
+        "in-progress": lambda r: r.is_in_progress,
+        "pending": lambda r: r.is_pending,
+    }
+    func = status_lut[status]
+    return list(filter(func, job_requests))
+
+
+class Dashboard(ListView):
+    """
+    User-centric Jobs List
+
+    This is a barely-modified version of JobRequestList for now, but is
+    expected to grow more User-centric features.
+    """
+
+    ordering = "-pk"
+    paginate_by = 25
+    template_name = "job_list.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return redirect("job-list")
+
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        # FIXME: This is a hack, see filter_by_status docstring for why and
+        # when to remove it
+        context["object_list"] = filter_by_status(
+            self.object_list, self.request.GET.get("status")
+        )
+
+        context["statuses"] = ["completed", "failed", "in-progress", "pending"]
+        context["workspaces"] = Workspace.objects.all()
+        return context
+
+    def get_queryset(self):
+        qs = (
+            JobRequest.objects.filter(created_by=self.request.user)
+            .prefetch_related("jobs")
+            .select_related("workspace")
+        )
+
+        q = self.request.GET.get("q")
+        if q:
+            try:
+                q = int(q)
+            except ValueError:
+                qs = qs.filter(jobs__action_id__icontains=q)
+            else:
+                # if the query looks enough like a number for int() to handle
+                # it then we can look for a job number
+                qs = qs.filter(Q(jobs__action_id__icontains=q) | Q(jobs__pk=q))
+
+        workspace = self.request.GET.get("workspace")
+        if workspace:
+            qs = qs.filter(workspace_id=workspace)
+
+        return qs
+
+
 class JobDetail(DetailView):
     model = Job
     queryset = Job.objects.select_related("workspace")
     template_name = "job_detail.html"
 
 
-class JobList(ListView):
+class JobRequestList(ListView):
     ordering = "-pk"
     paginate_by = 25
     template_name = "job_list.html"
-
-    def filter_by_status(self):
-        """
-        Filter JobRequests by possible status
-
-        Status is currently inferred from various Job fields and "bubbled up"
-        to a JobRequest.  This converts the view's QuerySet to a list via a
-        filter which uses properties on JobRequest to cut down the values to
-        those requested.
-
-        TODO: replace with a custom QuerySet once status is driven entirely via
-        the job-runner
-        """
-        status = self.request.GET.get("status")
-
-        if not status:
-            return self.object_list
-
-        status_lut = {
-            "completed": lambda r: r.is_complete,
-            "failed": lambda r: r.is_failed,
-            "in-progress": lambda r: r.is_in_progress,
-            "pending": lambda r: r.is_pending,
-        }
-        func = status_lut[status]
-        return list(filter(func, self.object_list))
 
     def get_context_data(self, **kwargs):
         # only get Users created via GitHub OAuth
@@ -55,7 +110,9 @@ class JobList(ListView):
 
         # FIXME: This is a hack, see filter_by_status docstring for why and
         # when to remove it
-        context["object_list"] = self.filter_by_status()
+        context["object_list"] = filter_by_status(
+            self.object_list, self.request.GET.get("status")
+        )
 
         context["statuses"] = ["completed", "failed", "in-progress", "pending"]
         context["users"] = {u.username: u.get_full_name() for u in users}
@@ -173,5 +230,4 @@ class WorkspaceSelectOrCreate(CreateView):
         instance = form.save(commit=False)
         instance.created_by = self.request.user
         instance.save()
-
         return redirect("job-create", pk=instance.pk)

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -85,14 +85,14 @@ header {
 }
 .filters .list-group-item a:first-child {
   display: inline-block;
-  padding: .75rem 1.25rem;
+  padding: .75rem .25rem .75rem 1.25rem;
 }
 .filters .list-group-item.active a:first-child {
   color: white;
 }
 .filters .list-group-item.active a.close {
   display: inline-block;
-  margin: .75rem 1.25rem;
+  margin: .75rem 1.25rem .75rem .25rem;
   opacity: 1;
 }
 .filters .list-group-item.active a.close span {


### PR DESCRIPTION
This adds a page at `/` (instead of redirecting users to `/jobs` which shows `JobRequest`s for the currently logged in User.  Anonymous Users are redirected to `/jobs` as before so the general Jobs feed can stay open to the public.

As the Dashboard docstring says this is a near identical copy of the `JobRequestList` view but is expected to diverge as we add more features.

Fixes #98 