### PR TITLE
Add a Job directly from a Workspace

### DIFF
--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -21,6 +21,10 @@
 
     <h3 class="text-center">Tools</h3>
 
+    <a class="btn btn-block btn-secondary" href="{% url 'job-create' pk=workspace.pk %}">
+      Add Job
+    </a>
+
     <a class="btn btn-block btn-secondary" href="{% url 'job-list' %}?workspace={{ workspace.pk }}">
       View Jobs
     </a>


### PR DESCRIPTION
This adds a button to the Workspace detail page to take the User to the Add Job page, skipping the select Workspace page.

Fixes #118 