### PR TITLE
Job Request List Mobile Fixes

### DIFF
--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -79,7 +79,9 @@
                 aria-expanded="false"
                 aria-controls="group-{{ group.pk }}"
                 >
-                Show/Hide Individual Jobs
+                Show/Hide
+                <span class="d-none d-lg-inline">Individual</span>
+                <span class="d-none d-md-inline">Jobs</span>
               </button>
             </div>
           </div>

--- a/jobserver/templates/job_list.html
+++ b/jobserver/templates/job_list.html
@@ -50,9 +50,9 @@
         <div class="d-flex">
           <div class="status"></div>
           <div class="workspace"><strong>Workspace</strong></div>
-          <div class="job-count"><strong>Jobs</strong></div>
-          <div class="action"><strong>Requested Action</strong></div>
-          <div class="started-at"><strong>Started</strong></div>
+          <div class="d-none d-md-block job-count"><strong>Jobs</strong></div>
+          <div class="d-none d-md-block action"><strong>Requested Action</strong></div>
+          <div class="d-none d-lg-block started-at"><strong>Started</strong></div>
           <div class="runtime"><strong>Runtime</strong></div>
         </div>
 
@@ -60,12 +60,12 @@
         <div class="job-request">
           <div class="d-flex align-items-center py-2">
             <div class="status">{% status_icon group.status %}</div>
-            <div class="workspace">{{ group.workspace.name }}</div>
-            <div class="job-count">{{ group.num_completed }}/{{ group.jobs.all|length }}</div>
-            <div class="action text-truncate" title="group.requested_action">
+            <div class="text-truncate workspace">{{ group.workspace.name }}</div>
+            <div class="d-none d-md-block job-count">{{ group.num_completed }}/{{ group.jobs.all|length }}</div>
+            <div class="d-none d-md-block action text-truncate" title="group.requested_action">
               {{ group.requested_action }}
             </div>
-            <div class="started-at">{{ group.started_at|naturaltime|default_if_none:"-" }}</div>
+            <div class="d-none d-lg-block started-at">{{ group.started_at|naturaltime|default_if_none:"-" }}</div>
             <div class="runtime">{% runtime group.runtime %}</div>
             <div class="mx-2">
               <button

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -14,6 +14,7 @@ header {
 }
 .job-list .job-requests .workspace {
   margin-right: .5rem;
+  min-width: 85px;
   width: 10%;
 }
 .job-list .job-requests .job-count {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -9,8 +9,7 @@ header {
   border-top: 2px solid #dee2e6;
 }
 .job-list .job-requests .status {
-  margin-left: .5rem;
-  margin-right: 1rem;
+  margin: 0 .5rem;
   width: 16px;
 }
 .job-list .job-requests .workspace {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -30,7 +30,7 @@ header {
 }
 .job-list .job-requests .runtime {
   margin-right: .5rem;
-  min-width: 206px;
+  min-width: 70px;
   flex-grow: 1;
 }
 .job-list .spinner svg {


### PR DESCRIPTION
This improves the JobRequest portion of the Jobs list page on mobile/different viewport configurations.  It selectively removes columns as the viewport collapses and cuts out words from the Job list toggle button at the same time.

Note: I tried to build this with Grid as per thoughts in #120 but lining up the cells to make borders work didn't look easy (possible?).  Since we needed to remove columns at smaller viewports anyway this turned out to be Good Enough™.

#### Desktop
![](https://p198.p4.n0.cdn.getcloudapp.com/items/7Ku8AP5g/Image%202020-10-20%20at%202.01.20%20pm.png?v=9c5e89aee41d7c5ed43ef02deaa3147a)

#### iPad (768x1024)
![](https://p198.p4.n0.cdn.getcloudapp.com/items/nOun5Pmw/Image%202020-10-20%20at%202.10.19%20pm.png?v=29348260ec38aa2fdacaed896fb6d782)

#### iPhone X/XS (375x812)
![](https://p198.p4.n0.cdn.getcloudapp.com/items/v1uxjYrO/Image%202020-10-20%20at%202.11.05%20pm.png?v=be651dd98cea9f9ac3af009610c22329)

Fixes #120 