### PR TITLE
Add site-wide banner espousing Alpha status

### DIFF
--- a/jobserver/templates/base.html
+++ b/jobserver/templates/base.html
@@ -52,6 +52,11 @@
 
     <div class="container-fluid">
 
+      <div class="alert alert-danger text-center mb-3" role="alert">
+        This site is still in early Alpha, some contents may currently be
+        incorrect, and historic data may disappear.
+      </div>
+
       {% for message in messages %}
       <div class="alert {{ message.tags }} alert-dismissible mb-3" role="alert">
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">


### PR DESCRIPTION
This adds a banner explaining the Alpha status of this site.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/2NujPPBl/Image%202020-10-20%20at%202.55.52%20pm.png?v=c5d116768487b28a0115ee0763eb8140)

Fixes #123 