### PR TITLE
Only Set started_at Once

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -174,7 +174,7 @@ class Job(models.Model):
         return "Pending"
 
     def save(self, *args, **kwargs):
-        if self.started:
+        if self.started and not self.started_at:
             self.started_at = datetime.datetime.now(tz=pytz.UTC)
 
         if self.status_code is not None and not self.completed_at:

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -146,6 +146,24 @@ def test_job_save(freezer):
 
 
 @pytest.mark.django_db
+def test_job_save_with_started_at_set(freezer):
+    job = JobFactory()
+
+    assert job.started_at is None
+    assert job.completed_at is None
+
+    start = timezone.now() - timedelta(hours=1)
+
+    job.started = True
+    job.started_at = start
+    job.status_code = 1
+    job.save()
+
+    assert job.started_at == start
+    assert job.completed_at == timezone.now()
+
+
+@pytest.mark.django_db
 def test_job_str():
     job = JobFactory(action_id="Run")
 


### PR DESCRIPTION
This changes `Job.save()` to only set `Job.started_at` when it hasn't already been set so we don't overwrite it on each subsequent save after creation.

Fixes #127 