### PR TITLE
Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: "Install dependencies"
         run: |
           set -xe
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Use the cached venv
         uses: actions/cache@v2
         with:
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Use the cached venv
         uses: actions/cache@v2
         with:
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Use the cached venv
         uses: actions/cache@v2
         with:
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: "actions/setup-python@v2"
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Use the cached venv
         uses: actions/cache@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.9-buster
 
 # Don't cache PyPI downloads or wheels.
 # Don't use pyc files or __pycache__ folders.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.6-slim-buster
+FROM python:3.9-slim-buster
 
 # Don't cache PyPI downloads or wheels.
 # Don't use pyc files or __pycache__ folders.

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -173,8 +173,7 @@ class JobRequestCreate(CreateView):
         self.actions = {}
         for action, children in actions_and_needs.items():
             status = self.workspace.get_latest_status_for_action(action)
-            children.update({"status": status})
-            self.actions[action] = children
+            self.actions[action] = children | {"status": status}
 
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
This updates us to Python 3.9.

It seems some of our dependencies don't have wheels for debian with 3.9 so this also moves us away from a slim build so don't have to manually install build tooling.