### PR TITLE
List Repos and Branches

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -5,19 +5,8 @@ from furl import furl
 
 
 BASE_URL = "https://api.github.com"
-
 TOKEN = os.environ["GITHUB_TOKEN"]
-
-
-def _build_headers(accept=None):
-    if accept is None:
-        accept = "application/vnd.github.v3+json"
-
-    return {
-        "Accept": accept,
-        "Authorization": f"token {TOKEN}",
-        "User-Agent": "OpenSAFELY Jobs",
-    }
+USER_AGENT = "OpenSAFELY Jobs"
 
 
 def get_file(repo, branch):
@@ -31,7 +20,11 @@ def get_file(repo, branch):
     ]
     f.args["ref"] = branch
 
-    headers = _build_headers(accept="application/vnd.github.3.raw")
+    headers = {
+        "Accept": "application/vnd.github.3.raw",
+        "Authorization": f"token {TOKEN}",
+        "User-Agent": USER_AGENT,
+    }
     r = requests.get(f.url, headers=headers)
     r.raise_for_status()
 

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -29,3 +29,49 @@ def get_file(repo, branch):
     r.raise_for_status()
 
     return r.text
+
+
+def get_repos_with_branches():
+    """
+    Get Repos with their branches from the OpenSafely Researchers Team
+
+    This uses the GraphQL API to avoid making O(N) calls to GitHub's (v3) REST
+    API.
+    """
+    query = """
+    query {
+      organization(login: "opensafely") {
+        team(slug: "researchers") {
+          repositories(first: 100) {
+            nodes {
+              name
+              url
+              refs(refPrefix: "refs/heads/", first: 100) {
+                nodes {
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    payload = {"query": query}
+
+    headers = {
+        "Authorization": f"bearer {TOKEN}",
+        "User-Agent": USER_AGENT,
+    }
+    r = requests.post("https://api.github.com/graphql", headers=headers, json=payload)
+    r.raise_for_status()
+    repos = r.json()["data"]["organization"]["team"]["repositories"]["nodes"]
+
+    for repo in repos:
+        branches = [b["name"] for b in repo["refs"]["nodes"]]
+
+        yield {
+            "name": repo["name"],
+            "url": repo["url"],
+            "branches": branches,
+        }

--- a/jobserver/templates/base.html
+++ b/jobserver/templates/base.html
@@ -71,9 +71,8 @@
     </div>
 
     <!-- JavaScript -->
-    {% block extra_js %}
     <script src="{% static 'js/jquery-3.5.1.slim.min.js' %}"></script>
     <script src="{% static 'js/bootstrap-4.5.2.min.js' %}"></script>
-    {% endblock %}
+    {% block extra_js %}{% endblock %}
   </body>
 </html>

--- a/jobserver/templates/workspace_select.html
+++ b/jobserver/templates/workspace_select.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% load crispy_forms_tags %}
+{% load static %}
 
 {% block content %}
 
@@ -33,3 +34,8 @@
   </div>
 </div>
 {% endblock content %}
+
+{% block extra_js %}
+{{ repos_with_branches|json_script:"reposWithBranches" }}
+<script type="text/javascript" src="{% static 'js/workspace_select.js' %}"></script>
+{% endblock %}

--- a/static/js/workspace_select.js
+++ b/static/js/workspace_select.js
@@ -1,0 +1,24 @@
+const setBranches = (reposWithBranches, repoURL) => {
+  /*
+   * Set Branches for a given Repo
+   */
+  const repo = reposWithBranches.find(r => r.url === repoURL)
+
+  // clear current options
+  $("#id_branch option").remove();
+
+  const select = $("#id_branch");
+  repo.branches.forEach(branch => {
+    // Set master or main branches as the default selected option
+    const selected = branch === "master" || branch === "main";
+    select.append(new Option(branch, branch, selected, selected));
+  })
+};
+
+$(document).ready(() => {
+  const reposWithBranches = JSON.parse(document.getElementById('reposWithBranches').textContent);
+
+  $("#id_repo").change((event) => setBranches(reposWithBranches, event.target.value));
+
+  setBranches(reposWithBranches, $("#id_repo").val());
+});

--- a/tests/jobserver/test_forms.py
+++ b/tests/jobserver/test_forms.py
@@ -1,7 +1,7 @@
 import pytest
 from django.core.exceptions import ValidationError
 
-from jobserver.forms import JobRequestCreateForm
+from jobserver.forms import JobRequestCreateForm, WorkspaceCreateForm
 
 
 def test_jobrequestcreateform_all_backends():
@@ -26,3 +26,66 @@ def test_jobrequestcreateform_unknown_backend():
 
     with pytest.raises(ValidationError):
         form.clean_backends()
+
+
+def test_workspacecreateform_success():
+    data = {
+        "name": "test",
+        "db": "dummy",
+        "repo": "http://example.com/derp/test-repo",
+        "branch": "test-branch",
+    }
+    repos_with_branches = [
+        {
+            "name": "test-repo",
+            "url": "http://example.com/derp/test-repo",
+            "branches": ["test-branch"],
+        }
+    ]
+    form = WorkspaceCreateForm(repos_with_branches, data)
+
+    assert form.is_valid()
+
+
+def test_workspacecreateform_unknown_branch():
+    repos_with_branches = [
+        {
+            "name": "test-repo",
+            "url": "http://example.com/derp/test-repo",
+            "branches": ["test-branch"],
+        }
+    ]
+    form = WorkspaceCreateForm(repos_with_branches)
+    form.cleaned_data = {
+        "name": "test",
+        "db": "dummy",
+        "repo": "http://example.com/derp/test-repo",
+        "branch": "unknown-branch",
+    }
+
+    with pytest.raises(ValidationError) as e:
+        form.clean_branch()
+
+    assert e.value.message.startswith("Unknown branch")
+
+
+def test_workspacecreateform_unknown_repo():
+    repos_with_branches = [
+        {
+            "name": "test-repo",
+            "url": "http://example.com/derp/test-repo",
+            "branches": ["test-branch"],
+        }
+    ]
+    form = WorkspaceCreateForm(repos_with_branches)
+    form.cleaned_data = {
+        "name": "test",
+        "db": "dummy",
+        "repo": "unknown-repo",
+        "branch": "test-branch",
+    }
+
+    with pytest.raises(ValidationError) as e:
+        form.clean_branch()
+
+    assert e.value.message.startswith("Unknown repo")

--- a/tests/jobserver/test_github.py
+++ b/tests/jobserver/test_github.py
@@ -1,6 +1,6 @@
 import responses
 
-from jobserver.github import get_file
+from jobserver.github import get_file, get_repos_with_branches
 
 
 @responses.activate
@@ -13,6 +13,48 @@ def test_get_file():
     assert len(responses.calls) == 1
 
     call = responses.calls[0]
-    # check the special case header is correct
+
+    # check the headers are correct
+    assert "token" in call.request.headers["Authorization"]
     assert call.request.headers["Accept"] == "application/vnd.github.3.raw"
+
     assert call.response.text == "a file!"
+
+
+@responses.activate
+def test_get_repos_with_branches():
+    data = {
+        "data": {
+            "organization": {
+                "team": {
+                    "repositories": {
+                        "nodes": [
+                            {
+                                "name": "test-repo",
+                                "url": "http://example.com/test/test/",
+                                "refs": {
+                                    "nodes": [
+                                        {"name": "branch1"},
+                                        {"name": "branch2"},
+                                    ]
+                                },
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    expected_url = "https://api.github.com/graphql"
+    responses.add(responses.POST, url=expected_url, json=data, status=200)
+
+    output = list(get_repos_with_branches())
+
+    assert len(responses.calls) == 1
+
+    # check the headers are correct
+    assert "bearer" in responses.calls[0].request.headers["Authorization"]
+
+    assert len(output) == 1
+    assert output[0]["name"] == "test-repo"
+    assert output[0]["branches"][0] == "branch1"

--- a/tests/jobserver/test_github.py
+++ b/tests/jobserver/test_github.py
@@ -1,17 +1,6 @@
 import responses
 
-from jobserver.github import _build_headers, get_file
-
-
-def test_build_headers():
-    headers = _build_headers()
-
-    assert headers["Accept"] == "application/vnd.github.v3+json"
-    assert headers["Authorization"] == "token dummy_token"
-    assert headers["User-Agent"] == "OpenSAFELY Jobs"
-
-    headers = _build_headers(accept="different accept")
-    assert headers["Accept"] == "different accept"
+from jobserver.github import get_file
 
 
 @responses.activate

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -305,7 +305,9 @@ def test_jobrequestcreate_success_with_all_backends(rf):
 @pytest.mark.django_db
 def test_jobrequestcreate_unknown_workspace_redirects_to_select_workspace_form(client):
     client.force_login(UserFactory())
-    response = client.post("/jobs/new/0/", follow=True)
+
+    with patch("jobserver.views.get_repos_with_branches", new=lambda *args: []):
+        response = client.post("/jobs/new/0/", follow=True)
 
     assert response.status_code == 200
     assert response.redirect_chain == [(reverse("job-select-workspace"), 302)]
@@ -328,7 +330,10 @@ def test_workspacecreate_redirects_to_new_workspace(rf):
     # Build a RequestFactory instance
     request = rf.post(MEANINGLESS_URL, data)
     request.user = user
-    response = WorkspaceCreate.as_view()(request)
+
+    repos = [{"name": "Test", "url": "test", "branches": ["test"]}]
+    with patch("jobserver.views.get_repos_with_branches", new=lambda *args: repos):
+        response = WorkspaceCreate.as_view()(request)
 
     assert response.status_code == 302
 
@@ -384,7 +389,10 @@ def test_workspaceselectorcreate_redirects_to_new_workspace(rf):
     # Build a RequestFactory instance
     request = rf.post(MEANINGLESS_URL, data)
     request.user = UserFactory()
-    response = WorkspaceSelectOrCreate.as_view()(request)
+
+    repos = [{"name": "Test", "url": "test", "branches": ["test"]}]
+    with patch("jobserver.views.get_repos_with_branches", new=lambda *args: repos):
+        response = WorkspaceSelectOrCreate.as_view()(request)
 
     assert response.status_code == 302
 
@@ -396,9 +404,13 @@ def test_workspaceselectorcreate_redirects_to_new_workspace(rf):
 def test_workspaceselectorcreate_success(rf):
     WorkspaceFactory()
     WorkspaceFactory()
+
     # Build a RequestFactory instance
     request = rf.get(MEANINGLESS_URL)
     request.user = UserFactory()
-    response = WorkspaceSelectOrCreate.as_view()(request)
+
+    with patch("jobserver.views.get_repos_with_branches", new=lambda *args: []):
+        response = WorkspaceSelectOrCreate.as_view()(request)
+
     assert response.status_code == 200
     assert len(response.context_data["workspace_list"]) == 2


### PR DESCRIPTION
This enhances the select-or-create Workspace page's Repo and Branch fields to be driven by live GitHub data.  To avoid O(N) requests to GitHub's API I've used their GraphQL (v4) API to create a list of repo-with-branches dictionaries from which the form is generated.

The branch selector is driven by some JavaScript so we don't end up with a giant list or the set of all branches.  The data driving this is loaded into the template to avoid any further API lookups.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/llu2dpkB/Screen%20Recording%202020-10-26%20at%2012.04.58%20pm.gif?v=7dc1f0f1469f4ad611b6ad0bbf83dda6)

Fixes #92 