### PR TITLE
Handle Missing project.yml

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -26,6 +26,10 @@ def get_file(repo, branch):
         "User-Agent": USER_AGENT,
     }
     r = requests.get(f.url, headers=headers)
+
+    if r.status_code == 404:
+        return
+
     r.raise_for_status()
 
     return r.text

--- a/jobserver/project.py
+++ b/jobserver/project.py
@@ -10,6 +10,9 @@ def load_yaml(content):
 def get_actions(repo, branch):
     """Get actions from project.yaml for this Workspace"""
     content = get_file(repo, branch)
+    if content is None:
+        return {}
+
     project = load_yaml(content)
 
     for action, children in project["actions"].items():

--- a/jobserver/templates/job_create.html
+++ b/jobserver/templates/job_create.html
@@ -4,6 +4,14 @@
 
 {% block content %}
 
+{% if not actions_data %}
+<div class="my-5 text-center">
+  <p>
+    It looks like the branch <code>{{ branch }}</code> doesn't have a <code>project.yaml</code>.
+  </p>
+  <p>Create one and reload this page to continue.</p>
+</div>
+{% else %}
 <div class="row job-create">
   <div class="col-8 offset-2">
 
@@ -149,4 +157,5 @@
 
   </div>
 </div>
+{% endif %}
 {% endblock content %}

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -201,6 +201,7 @@ class JobRequestCreate(CreateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["actions_data"] = self.actions
+        context["branch"] = self.workspace.branch
         return context
 
     def get_form_kwargs(self):

--- a/tests/jobserver/test_github.py
+++ b/tests/jobserver/test_github.py
@@ -22,6 +22,24 @@ def test_get_file():
 
 
 @responses.activate
+def test_get_file_missing_project_yml():
+    expected_url = "https://api.github.com/repos/opensafely/some_repo/contents/project.yaml?ref=missing_project"
+    responses.add(responses.GET, expected_url, status=404)
+
+    output = get_file("some_repo", "missing_project")
+
+    assert len(responses.calls) == 1
+
+    call = responses.calls[0]
+
+    # check the headers are correct
+    assert "token" in call.request.headers["Authorization"]
+    assert call.request.headers["Accept"] == "application/vnd.github.3.raw"
+
+    assert output is None
+
+
+@responses.activate
 def test_get_repos_with_branches():
     data = {
         "data": {


### PR DESCRIPTION
This adds in handling for Branches which don't contain a `project.yaml` file.  I opted to replace the entire page to avoid Users having the option to fill in a partially rendered form since they'll need to reload the page to get actions anyway.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/4guJegWg/Image%202020-10-26%20at%201.51.07%20pm.png?v=db80838002b5b5d6d2035e9a42e8f250)