### PR TITLE
Add some visual distinction between My and All Jobs

### DIFF
--- a/jobserver/templates/dashboard.html
+++ b/jobserver/templates/dashboard.html
@@ -1,0 +1,15 @@
+{% extends "job_list_base.html" %}
+
+{% load querystring_tools %}
+
+{% block title %}My Jobs{% endblock %}
+
+{% block empty_list %}
+<div class="text-center">
+  <p>No results found, <a href="{% url 'job-list' %}">Clear all filters</a>?</p>
+
+  <p>OR</p>
+
+  <p>Try your query across <a href={% redirect_with_querystring 'job-list' %}>All Jobs</a>?<p>
+</div>
+{% endblock %}

--- a/jobserver/templates/job_list_base.html
+++ b/jobserver/templates/job_list_base.html
@@ -12,7 +12,7 @@
 <div class="job-list">
   <div class="d-flex justify-content-between mt-3 mb-4">
 
-    <h2>Jobs</h2>
+    <h2>{% block title %}{% endblock %}</h2>
 
     {% if user.is_authenticated %}
     <div>
@@ -39,11 +39,8 @@
     </form>
 
 
-      {% if not object_list %}
-      <div class="text-center">
-        <p>No results found.</p>
-        <a href="{% url 'job-list' %}">Clear all filters?</a>
-      </div>
+      {% if not page_obj %}
+      {% block empty_list %}{% endblock %}
       {% else %}
 
       <div class="job-requests">

--- a/jobserver/templates/jobrequest_list.html
+++ b/jobserver/templates/jobrequest_list.html
@@ -1,0 +1,10 @@
+{% extends "job_list_base.html" %}
+
+{% block title %}All Jobs{% endblock %}
+
+{% block empty_list %}
+<div class="text-center">
+  <p>No results found.</p>
+  <a href="{% url 'job-list' %}">Clear all filters?</a>
+</div>
+{% endblock %}

--- a/jobserver/templatetags/querystring_tools.py
+++ b/jobserver/templatetags/querystring_tools.py
@@ -1,8 +1,18 @@
 from django import template
+from django.urls import reverse
 from furl import furl
 
 
 register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def redirect_with_querystring(context, view_name):
+    request = context["request"]
+    f = furl(request.get_full_path())
+    f.path = reverse(view_name)
+
+    return f.url
 
 
 @register.simple_tag(takes_context=True)

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -47,7 +47,7 @@ class Dashboard(ListView):
     """
 
     paginate_by = 25
-    template_name = "job_list.html"
+    template_name = "dashboard.html"
 
     def dispatch(self, request, *args, **kwargs):
         if not request.user.is_authenticated:
@@ -102,7 +102,7 @@ class JobDetail(DetailView):
 
 class JobRequestList(ListView):
     paginate_by = 25
-    template_name = "job_list.html"
+    template_name = "jobrequest_list.html"
 
     def get_context_data(self, **kwargs):
         # only get Users created via GitHub OAuth


### PR DESCRIPTION
This is the start of adding some visual distinction between the Dashboard (currently logged in user) and Jobs pages.

So far:
* Different titles
* Dashboard gains a link to the Jobs page with the current filters maintained

#### Dashboard
![](https://p198.p4.n0.cdn.getcloudapp.com/items/7Ku8zeR6/Image%202020-10-27%20at%202.02.49%20pm.png?v=f61a3fbe013032759ffa35c6d3f7c824)

#### All Jobs
![](https://p198.p4.n0.cdn.getcloudapp.com/items/p9uwegXx/Image%202020-10-27%20at%202.07.51%20pm.png?v=439e7014de11062b27ae9dd242601459)

Fixes #148 