### PR TITLE
Fix Requested Actions

### DIFF
--- a/jobserver/templates/job_list_base.html
+++ b/jobserver/templates/job_list_base.html
@@ -48,7 +48,7 @@
           <div class="status"></div>
           <div class="workspace"><strong>Workspace</strong></div>
           <div class="d-none d-md-block job-count"><strong>Jobs</strong></div>
-          <div class="d-none d-md-block action"><strong>Requested Action</strong></div>
+          <div class="d-none d-md-block action"><strong>Requested Actions</strong></div>
           <div class="d-none d-lg-block started-at"><strong>Started</strong></div>
           <div class="runtime"><strong>Runtime</strong></div>
         </div>
@@ -59,8 +59,8 @@
             <div class="status">{% status_icon group.status %}</div>
             <div class="text-truncate workspace">{{ group.workspace.name }}</div>
             <div class="d-none d-md-block job-count">{{ group.num_completed }}/{{ group.jobs.all|length }}</div>
-            <div class="d-none d-md-block action text-truncate" title="group.requested_action">
-              {{ group.requested_action }}
+            <div class="d-none d-md-block action text-truncate" title="{{ group.requested_actions|join:"," }}">
+              {{ group.requested_actions|join:"," }}
             </div>
             <div class="d-none d-lg-block started-at">{{ group.started_at|naturaltime|default_if_none:"-" }}</div>
             <div class="runtime">{% runtime group.runtime %}</div>


### PR DESCRIPTION
This fixes the `Requested Actions` field for `JobRequest`s in the job listing views to pull from the correct field, join the values with a comma, and correctly assign to the `title` attribute.