### PR TITLE
Show Backend

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -5,6 +5,7 @@ import requests
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.urls import reverse
+from django.utils import timezone
 from furl import furl
 
 from .runtime import Runtime
@@ -297,10 +298,8 @@ class JobRequest(models.Model):
         if self.started_at is None:
             return
 
-        if self.completed_at is None:
-            return
-
-        delta = self.completed_at - self.started_at
+        end = timezone.now() if self.completed_at is None else self.completed_at
+        delta = end - self.started_at
 
         hours, remainder = divmod(delta.total_seconds(), 3600)
         minutes, seconds = divmod(remainder, 60)

--- a/jobserver/templates/job_list_base.html
+++ b/jobserver/templates/job_list_base.html
@@ -49,7 +49,7 @@
           <div class="workspace"><strong>Workspace</strong></div>
           <div class="d-none d-md-block backend"></div>
           <div class="d-none d-md-block job-count"><strong>Jobs</strong></div>
-          <div class="d-none d-md-block action"><strong>Requested Actions</strong></div>
+          <div class="d-none d-md-block action"><strong>Requested Action</strong></div>
           <div class="d-none d-lg-block started-at"><strong>Started</strong></div>
           <div class="runtime"><strong>Runtime</strong></div>
         </div>
@@ -66,7 +66,6 @@
             <div class="d-none d-md-block action text-truncate" title="{{ group.requested_actions|join:"," }}">
               {{ group.requested_actions|join:"," }}
             </div>
-            <div class="d-none d-lg-block started-at">{{ group.started_at|naturaltime|default_if_none:"-" }}</div>
             <div class="runtime">{% runtime group.runtime %}</div>
             <div class="mx-2">
               <button

--- a/jobserver/templates/job_list_base.html
+++ b/jobserver/templates/job_list_base.html
@@ -47,6 +47,7 @@
         <div class="d-flex">
           <div class="status"></div>
           <div class="workspace"><strong>Workspace</strong></div>
+          <div class="d-none d-md-block backend"></div>
           <div class="d-none d-md-block job-count"><strong>Jobs</strong></div>
           <div class="d-none d-md-block action"><strong>Requested Actions</strong></div>
           <div class="d-none d-lg-block started-at"><strong>Started</strong></div>
@@ -58,6 +59,9 @@
           <div class="d-flex align-items-center py-2">
             <div class="status">{% status_icon group.status %}</div>
             <div class="text-truncate workspace">{{ group.workspace.name }}</div>
+            <div class="d-none d-md-block backend">
+                <span class="badge badge-secondary">{{ group.backend|upper }}</span>
+            </div>
             <div class="d-none d-md-block job-count">{{ group.num_completed }}/{{ group.jobs.all|length }}</div>
             <div class="d-none d-md-block action text-truncate" title="{{ group.requested_actions|join:"," }}">
               {{ group.requested_actions|join:"," }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -17,6 +17,10 @@ header {
   min-width: 85px;
   width: 10%;
 }
+.job-list .job-requests .backend {
+  margin-right: .5rem;
+  width: 40px;
+}
 .job-list .job-requests .job-count {
   margin-right: .5rem;
   width: 5%;


### PR DESCRIPTION
This adds a badge to each `JobRequest` row to show which backend it is for.  Since we're space constrained it also removes the `Started At` column and changes how `JobRequest.runtime` works to display a value once any related `Job` has started turning it into more of a running timer.

#### Small
![](https://p198.p4.n0.cdn.getcloudapp.com/items/geuqE0KL/Image%202020-10-27%20at%204.13.01%20pm.png?v=0cfcba86a5121569c16309a196884f86)

#### Medium
![](https://p198.p4.n0.cdn.getcloudapp.com/items/mXu6DEX1/Image%202020-10-27%20at%204.13.57%20pm.png?v=20de3e8752a3865b09e8e1167daa6947)

#### Large
![](https://p198.p4.n0.cdn.getcloudapp.com/items/6quPb049/Image%202020-10-27%20at%204.14.21%20pm.png?v=12a1a9c64cea709e2d90daa6c810e7a1)

Fixes #111 