### PR TITLE
Use Repo name when displaying Workspaces

### DIFF
--- a/jobserver/templates/workspace_select.html
+++ b/jobserver/templates/workspace_select.html
@@ -17,7 +17,7 @@
         class="list-group-item d-flex justify-content-between align-items-center"
         href="{% url 'job-create' pk=workspace.pk %}">
         <span class="mr-2">{{ workspace.name }}</span>
-        <code class="text-muted">{{ workspace.repo }}|{{ workspace.branch }}</code>
+        <code class="text-muted">{{ workspace.repo_name }}|{{ workspace.branch }}</code>
       </a>
       {% endfor %}
     </div>


### PR DESCRIPTION
This uses `Workspace.repo_name` since the full URL takes up a lot of space unnecessarily.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/qGuv6DNg/Image%202020-10-28%20at%203.58.45%20pm.png?v=703c19504085402b7bca0fb31e2f2134)

Fixes #156 