### PR TITLE
Fix Users Missing Names in Job Filters

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -333,4 +333,7 @@ class JobRequest(models.Model):
 
 
 class User(AbstractUser):
-    pass
+    @property
+    def name(self):
+        """Unify the available names for a User."""
+        return self.get_full_name() or self.username

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -107,6 +107,7 @@ class JobRequestList(ListView):
     def get_context_data(self, **kwargs):
         # only get Users created via GitHub OAuth
         users = User.objects.exclude(social_auth=None)
+        users = sorted(users, key=lambda u: u.name.lower())
 
         context = super().get_context_data(**kwargs)
 

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -118,7 +118,7 @@ class JobRequestList(ListView):
         )
 
         context["statuses"] = ["completed", "failed", "in-progress", "pending"]
-        context["users"] = {u.username: u.get_full_name() for u in users}
+        context["users"] = {u.username: u.name for u in users}
         context["workspaces"] = Workspace.objects.all()
         return context
 

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 
 from jobserver.models import Job
 
-from ..factories import JobFactory, JobRequestFactory, WorkspaceFactory
+from ..factories import JobFactory, JobRequestFactory, UserFactory, WorkspaceFactory
 
 
 @pytest.mark.django_db
@@ -512,6 +512,19 @@ def test_jobqueryset():
     assert Job.objects.completed().count() == 1
     assert Job.objects.in_progress().count() == 1
     assert Job.objects.pending().count() == 1
+
+
+@pytest.mark.django_db
+def test_user_name_with_first_and_last_name():
+    user = UserFactory(first_name="first", last_name="last")
+
+    assert user.name == "first last"
+
+
+@pytest.mark.django_db
+def test_user_name_without_first_and_last_name():
+    user = UserFactory()
+    assert user.name == user.username
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This adds a property to our User model to always get a name for a given User, and fixes the Jobs list filter by using that name so GitHub users who haven't set a name can still filter Jobs.

Fixes #147 