### PR TITLE
Job List Visual Tweaks

### DIFF
--- a/jobserver/templates/job_list_base.html
+++ b/jobserver/templates/job_list_base.html
@@ -50,7 +50,6 @@
           <div class="d-none d-md-block backend"></div>
           <div class="d-none d-md-block job-count"><strong>Jobs</strong></div>
           <div class="d-none d-md-block action"><strong>Requested Action</strong></div>
-          <div class="d-none d-lg-block started-at"><strong>Started</strong></div>
           <div class="runtime"><strong>Runtime</strong></div>
         </div>
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -29,10 +29,6 @@ header {
   margin-right: .5rem;
   width: 15%;
 }
-.job-list .job-requests .started-at {
-  margin-right: .5rem;
-  width: 20%;
-}
 .job-list .job-requests .runtime {
   margin-right: .5rem;
   min-width: 70px;


### PR DESCRIPTION
This removes the previously-missed `Started` column header on the Job List page.