### PR TITLE
Remove backend choices for JobRequests

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -6,13 +6,8 @@ from .models import JobRequest, Workspace
 
 
 class JobRequestCreateForm(forms.ModelForm):
-    ALL = ("all", "All")
-    BACKEND_CHOICES = [ALL] + JobRequest.BACKEND_CHOICES
-    backends = forms.ChoiceField(label="Backend", choices=BACKEND_CHOICES)
-
     class Meta:
         fields = [
-            "backends",
             "force_run",
             "force_run_dependencies",
             "callback_url",
@@ -32,25 +27,6 @@ class JobRequestCreateForm(forms.ModelForm):
         self.fields["requested_actions"] = forms.MultipleChoiceField(
             choices=choices, widget=forms.CheckboxSelectMultiple
         )
-
-    def clean_backends(self):
-        """
-        Validate backends selector
-
-        Users can select one or All backends in the form, so we want to always
-        give calling code a list of backends.
-        """
-        all_backends = [choice[0] for choice in JobRequest.BACKEND_CHOICES]
-
-        selected = self.cleaned_data["backends"]
-        if selected not in all_backends + [self.ALL[0]]:
-            raise forms.ValidationError("Unknown backend", code="unknown")
-
-        # always return a list
-        if selected != self.ALL[0]:
-            return [selected]
-
-        return all_backends
 
 
 class WorkspaceCreateForm(forms.ModelForm):
@@ -93,5 +69,4 @@ class WorkspaceCreateForm(forms.ModelForm):
         branches = [b.lower() for b in repo["branches"]]
         if branch.lower() not in branches:
             raise forms.ValidationError(f'Unknown branch "{branch}"')
-
         return branch

--- a/jobserver/templates/job_create.html
+++ b/jobserver/templates/job_create.html
@@ -28,21 +28,6 @@
 
       <div class="form-group">
 
-        <label for="id_backends" class="requiredField">
-          Backend <span class="text-danger">*</span>
-        </label>
-
-        <select name="backends" class="select form-control" id="id_backends">
-          {% for value, label in form.backends.field.choices %}
-          <option
-            {% if form.backends.value == value %}selected{% endif %}
-            value="{{ value }}"
-            >
-            {{ label }}
-          </option>
-          {% endfor %}
-        </select>
-
         {% if form.backend.errors %}
         <ul class="pl-3 mb-1">
           {% for error in form.backend.errors %}

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -183,21 +183,18 @@ class JobRequestCreate(CreateView):
     def form_valid(self, form):
         sha = get_branch_sha(self.workspace.repo_name, self.workspace.branch)
 
-        # pop backends as it's not a field on JobRequest
-        backends = form.cleaned_data.pop("backends")
-        for backend in backends:
-            job_request = JobRequest.objects.create(
-                workspace=self.workspace,
-                created_by=self.request.user,
-                backend=backend,
-                sha=sha,
-                **form.cleaned_data,
+        job_request = JobRequest.objects.create(
+            workspace=self.workspace,
+            created_by=self.request.user,
+            backend=JobRequest.TPP,
+            sha=sha,
+            **form.cleaned_data,
+        )
+        for action in job_request.requested_actions:
+            job_request.jobs.create(
+                action_id=action,
+                force_run=job_request.force_run,
             )
-            for action in job_request.requested_actions:
-                job_request.jobs.create(
-                    action_id=action,
-                    force_run=job_request.force_run,
-                )
 
         return redirect("job-list")
 

--- a/tests/jobserver/test_forms.py
+++ b/tests/jobserver/test_forms.py
@@ -1,31 +1,7 @@
 import pytest
 from django.core.exceptions import ValidationError
 
-from jobserver.forms import JobRequestCreateForm, WorkspaceCreateForm
-
-
-def test_jobrequestcreateform_all_backends():
-    form = JobRequestCreateForm(data="", actions=["test"])
-    form.cleaned_data = {"backends": "all"}
-
-    output = form.clean_backends()
-    assert output == ["emis", "tpp"]
-
-
-def test_jobrequestcreateform_one_backend():
-    form = JobRequestCreateForm(actions=["test"])
-    form.cleaned_data = {"backends": "tpp"}
-
-    output = form.clean_backends()
-    assert output == ["tpp"]
-
-
-def test_jobrequestcreateform_unknown_backend():
-    form = JobRequestCreateForm(actions=["test"])
-    form.cleaned_data = {"backends": "test"}
-
-    with pytest.raises(ValidationError):
-        form.clean_backends()
+from jobserver.forms import WorkspaceCreateForm
 
 
 def test_workspacecreateform_success():


### PR DESCRIPTION
This removes the `backends` choice from the JobRequest page since we only have one backend currently and it's been causing some confusion (#111).

I've kept the backend badges on the list page as they're small and unobtrusive.

Fixes #157 