### PR TITLE
Ignore Specific Django Structlog Logger

### DIFF
--- a/services/sentry.py
+++ b/services/sentry.py
@@ -23,6 +23,7 @@ def initialise_sentry():
         return
 
     ignore_logger("django_structlog")
+    ignore_logger("django_structlog.middlewares.request")
 
     sentry_sdk.init(
         dsn,


### PR DESCRIPTION
We're already ignoring the root `django_structlog` logger, however we're still seeing ERROR logs from `django_structlog.middlewares.request` appear in Sentry, duplicating the exception reporting events already being sent.

Since we don't get a huge number of errors from this site it's been slow to test, but hoping this fixes the issue.

_exasperated noises_