### PR TITLE
Hide Callback URL

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -10,12 +10,8 @@ class JobRequestCreateForm(forms.ModelForm):
         fields = [
             "force_run",
             "force_run_dependencies",
-            "callback_url",
         ]
         model = JobRequest
-        widgets = {
-            "callback_url": forms.TextInput(),
-        }
 
     def __init__(self, actions, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/jobserver/templates/job_request_create.html
+++ b/jobserver/templates/job_request_create.html
@@ -84,24 +84,6 @@
 
       </div>
 
-      <div class="form-group mb-5">
-        <label for="id_callback_url">Callback URL</label>
-        <input
-          type="text"
-          name="callback_url"
-          class="form-control{% if form.callback_url.errors %} is-invalid{% endif %}"
-          id="id_callback_url"
-          />
-
-        {% if form.callback_url.errors %}
-        <ul>
-          {% for error in form.callback_url.errors %}
-          <li class="text-danger">{{ error }}</li>
-          {% endfor %}
-        </ul>
-        {% endif %}
-      </div>
-
       <p>Pick one or more actions to run:</p>
 
       <div class="form-group mb-5">


### PR DESCRIPTION
This removes the `callback_url` field from the create JobRequest form to avoid invalid URL entries in the short term.

Fixes #174 