### PR TITLE
Fix JobRequest Runtimes

### DIFF
--- a/jobserver/templates/job_list_base.html
+++ b/jobserver/templates/job_list_base.html
@@ -50,7 +50,7 @@
           <div class="d-none d-md-block backend"></div>
           <div class="d-none d-md-block job-count"><strong>Jobs</strong></div>
           <div class="d-none d-md-block action"><strong>Requested Action</strong></div>
-          <div class="runtime"><strong>Runtime</strong></div>
+          <div class="started-at"><strong>Started At</strong></div>
         </div>
 
         {% for group in page_obj %}
@@ -65,7 +65,7 @@
             <div class="d-none d-md-block action text-truncate" title="{{ group.requested_actions|join:"," }}">
               {{ group.requested_actions|join:"," }}
             </div>
-            <div class="runtime">{% runtime group.runtime %}</div>
+            <div class="started-at">{{ group.started_at|date:"Y-m-d H:i:s"|default:"-" }}</div>
             <div class="mx-2">
               <button
                 class="btn btn-sm btn-primary"

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -26,13 +26,13 @@ header {
   width: 5%;
 }
 .job-list .job-requests .action {
+  flex-grow: 1;
   margin-right: .5rem;
   width: 15%;
 }
-.job-list .job-requests .runtime {
+.job-list .job-requests .started-at {
   margin-right: .5rem;
-  min-width: 70px;
-  flex-grow: 1;
+  width: 160px;
 }
 .job-list .spinner svg {
   animation: spinner 1.2s linear infinite;


### PR DESCRIPTION
This replaces `JobRequest` runtimes with the time they started at (and reflows the columns so they make sense) on the JobRequest listing pages.  For a variety of reasons it's currently likely that JobRequets end up with their `completed_at` property returning None so they appear to never finish which means their `runtime` property runs off `timezone.now()`… forever increasing.

Fixes #178 