### PR TITLE
Correctly position Started At column header

### DIFF
--- a/jobserver/templates/job_list_base.html
+++ b/jobserver/templates/job_list_base.html
@@ -50,7 +50,7 @@
           <div class="d-none d-md-block backend"></div>
           <div class="d-none d-md-block job-count"><strong>Jobs</strong></div>
           <div class="d-none d-md-block action"><strong>Requested Action</strong></div>
-          <div class="started-at"><strong>Started At</strong></div>
+          <div id="started-at-header" class="started-at"><strong>Started At</strong></div>
         </div>
 
         {% for group in page_obj %}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -34,6 +34,23 @@ header {
   margin-right: .5rem;
   width: 160px;
 }
+
+#started-at-header {
+  margin-right: 112px;
+}
+@media (min-width: 768px) {
+  /* account for larger show/hide button */
+  #started-at-header {
+    margin-right: 147px;
+  }
+}
+@media (min-width: 992px) {
+  /* account for larger show/hide button */
+  #started-at-header {
+    margin-right: 212px;
+  }
+}
+
 .job-list .spinner svg {
   animation: spinner 1.2s linear infinite;
 }


### PR DESCRIPTION
This sets an appropriate right margin on the `Started At` column header for the three viewports we typically work to (small, medium and large in Bootstrap nomenclature) to work around the Show/Hide button widths.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/p9uw45DG/Image%202020-11-04%20at%2011.03.31%20am.png?v=64725be46750bee1d4ce5b3c8c03a05a)