### PR TITLE
Workspace fixes

### DIFF
--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -11,7 +11,12 @@
       <li class="pt-2"><strong>Repo:</strong> <a href="{{ workspace.repo }}">{{ workspace.repo_name }}</a></li>
       <li class="pt-2"><strong>Branch:</strong> {{ workspace.branch }}</li>
       <li class="pt-2"><strong>DB:</strong> {{ workspace.db }}</li>
-      <li class="pt-2"><strong>Created:</strong> {{ workspace.created_at|naturaltime }}</li>
+      <li class="pt-2">
+        <strong>Created:</strong>
+        <span title="{{ workspace.created_at|date:"Y-m-d H:i:s" }}">
+          {{ workspace.created_at|naturaltime }}
+        </span>
+      </li>
       {% if workspace.created_by %}
       <li class="pt-2"><strong>Created By:</strong> {{ workspace.created_by.name }}</li>
       {% endif %}

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -10,9 +10,11 @@
     <ul class="list-unstyled">
       <li class="pt-2"><strong>Repo:</strong> <a href="{{ workspace.repo }}">{{ workspace.repo_name }}</a></li>
       <li class="pt-2"><strong>Branch:</strong> {{ workspace.branch }}</li>
-      <li class="pt-2"><strong>Owner:</strong> {{ workspace.owner }}</li>
       <li class="pt-2"><strong>DB:</strong> {{ workspace.db }}</li>
       <li class="pt-2"><strong>Created:</strong> {{ workspace.created_at|naturaltime }}</li>
+      {% if workspace.created_by %}
+      <li class="pt-2"><strong>Created By:</strong> {{ workspace.created_by.name }}</li>
+      {% endif %}
     </ul>
 
   </div>

--- a/jobserver/templates/workspace_list.html
+++ b/jobserver/templates/workspace_list.html
@@ -36,7 +36,7 @@
         {% for workspace in page_obj %}
         <tr>
           <td>{{ workspace.name }}</td>
-          <td>{{ workspace.repo }}</td>
+          <td><a href="{{ workspace.repo }}">{{ workspace.repo_name }}</a></td>
           <td>{{ workspace.branch }}</td>
           <td>
             <a class="btn btn-secondary text-white" href="{% url 'workspace-detail' pk=workspace.pk %}">


### PR DESCRIPTION
This addressess a couple of quick usability fixes on the Workspace pages:
* use `repo_name` on the Workspace list page, and link it to the GitHub repo
* fix the owner/created_by field on the Workspace detail page
* add a title with the absolute datetime to the created_at field on the Workspace detail page

Fixes #183 
Fixes #184 