### PR TITLE
Use mobile friendly column sizing

### DIFF
--- a/jobserver/templates/job_request_create.html
+++ b/jobserver/templates/job_request_create.html
@@ -13,7 +13,7 @@
 </div>
 {% else %}
 <div class="row job-create">
-  <div class="col-8 offset-2">
+  <div class="col-lg-8 offset-lg-2">
 
     <form method="POST">
       {% csrf_token %}

--- a/jobserver/templates/landing.html
+++ b/jobserver/templates/landing.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block content %}
+derp
+{% endblock content %}

--- a/jobserver/templates/workspace_create.html
+++ b/jobserver/templates/workspace_create.html
@@ -5,7 +5,7 @@
 {% block content %}
 
 <div class="row">
-  <div class="col-8 offset-2">
+  <div class="col-md-8 offset-md-2">
     {% crispy form %}
   </div>
 </div>

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="row">
-  <div class="col-10">
+  <div class="col-lg-10">
     <h3>Workspace: {{ workspace.name }}</h3>
 
     <ul class="list-unstyled">
@@ -24,7 +24,7 @@
 
   </div>
 
-  <div class="col-2">
+  <div class="col-lg-2">
 
     <h3 class="text-center">Tools</h3>
 

--- a/jobserver/templates/workspace_list.html
+++ b/jobserver/templates/workspace_list.html
@@ -20,7 +20,7 @@
 
 <div class="row">
 
-  <div class="col-10">
+  <div class="col-lg-10">
 
     <table class="table table-hover">
       <thead>
@@ -80,7 +80,7 @@
     </div>
   </div>
 
-  <div class="col-2">
+  <div class="col-lg-2">
     <h4>Filters</h4>
 
   </div>

--- a/jobserver/templates/workspace_select.html
+++ b/jobserver/templates/workspace_select.html
@@ -6,7 +6,7 @@
 {% block content %}
 
 <div class="row workspace-select">
-  <div class="col-8 offset-2">
+  <div class="col-lg-8 offset-lg-2">
 
     {% if workspace_list %}
     <p>Select a Workspace before adding a Job:</p>
@@ -17,7 +17,9 @@
         class="list-group-item d-flex justify-content-between align-items-center"
         href="{% url 'job-create' pk=workspace.pk %}">
         <span class="mr-2">{{ workspace.name }}</span>
-        <code class="text-muted">{{ workspace.repo_name }}|{{ workspace.branch }}</code>
+        <code class="text-muted d-none d-md-block">
+          {{ workspace.repo_name }}|{{ workspace.branch }}
+        </code>
       </a>
       {% endfor %}
     </div>


### PR DESCRIPTION
This swaps out all remaining `col-[0-9]` classes for their `md` or `lg` variants so pages are more usable on phone and tablet sized viewports.

Fixes #124 