### PR TITLE
Ensure Admins are Configured on Boot

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 ./manage.py migrate
+./manage.py ensure_admins
 ./manage.py collectstatic --no-input
 
 exec "$@"

--- a/jobserver/management/commands/ensure_admins.py
+++ b/jobserver/management/commands/ensure_admins.py
@@ -1,0 +1,18 @@
+import sys
+
+from django.core.management.base import BaseCommand
+
+from jobserver.admins import ensure_admins, get_admins
+
+
+class Command(BaseCommand):
+    help = "Configure admins to "
+
+    def handle(self, *args, **options):
+        usernames = get_admins()
+
+        try:
+            ensure_admins(usernames)
+        except Exception as e:
+            print(str(e), file=sys.stderr)
+            sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ exclude = '''
 branch = true
 omit = [
   "jobserver/asgi.py",
+  "jobserver/management/commands/ensure_admins.py",
   "jobserver/management/commands/local_data.py",
   "jobserver/migrations/*",
   "jobserver/settings.py",

--- a/tests/jobserver/test_admins.py
+++ b/tests/jobserver/test_admins.py
@@ -1,0 +1,55 @@
+import pytest
+
+from jobserver.admins import ensure_admins, get_admins
+
+from ..factories import UserFactory
+
+
+@pytest.mark.django_db
+def test_ensure_admins_no_users_configured():
+    with pytest.raises(Exception, match="No admin users configured, aborting"):
+        ensure_admins([])
+
+
+@pytest.mark.django_db
+def test_ensure_admins_success():
+    user = UserFactory(username="ghickman")
+    assert not user.is_superuser
+
+    ensure_admins(["ghickman"])
+
+    user.refresh_from_db()
+    assert user.is_superuser
+
+
+@pytest.mark.django_db
+def test_ensure_admins_unknown_user():
+    user = UserFactory(username="ghickman")
+    assert not user.is_superuser
+
+    with pytest.raises(Exception, match="Unknown users: test"):
+        ensure_admins(["ghickman", "test"])
+
+
+@pytest.mark.django_db
+def test_ensure_admins_unknown_users():
+    user = UserFactory(username="ghickman")
+    assert not user.is_superuser
+
+    with pytest.raises(Exception, match="Unknown users: foo, test"):
+        ensure_admins(["ghickman", "foo", "test"])
+
+
+def test_get_admins_empty(monkeypatch):
+    monkeypatch.setenv("ADMIN_USERS", "")
+    assert get_admins() == []
+
+
+def test_get_admins_space_around_comma(monkeypatch):
+    monkeypatch.setenv("ADMIN_USERS", "test , foo")
+    assert get_admins() == ["test", "foo"]
+
+
+def test_get_admins_success(monkeypatch):
+    monkeypatch.setenv("ADMIN_USERS", "one,two,three")
+    assert get_admins() == ["one", "two", "three"]


### PR DESCRIPTION
This gives us an easy way to configure admins at application boot via env vars.

I originally had the code in `get_admins` as a one-liner in settings.py but realised it would be better to 1) test it, 2) document what it's doing and 3) pull it out of the global namespace.