### PR TITLE
Only log API access when response is a success

### DIFF
--- a/jobserver/middleware.py
+++ b/jobserver/middleware.py
@@ -14,8 +14,11 @@ def stats_middleware(get_response):
         if not request.path.startswith(API_PREFIX):
             return response
 
-        # only update the stats for API access
-        Stats.objects.update_or_create(pk=1, defaults={"api_last_seen": timezone.now()})
+        if response.status_code >= 200 and response.status_code < 300:
+            # only update the stats for API access when response is 2xx
+            Stats.objects.update_or_create(
+                pk=1, defaults={"api_last_seen": timezone.now()}
+            )
 
         return response
 


### PR DESCRIPTION
This changes our stats middleware to only log when a response is 2xx.

Previously we logged for any response status, including 403s (when we broke the auth), which gave false positives.