### PR TITLE
Hardcode API Prefix

### DIFF
--- a/jobserver/middleware.py
+++ b/jobserver/middleware.py
@@ -1,17 +1,13 @@
-from django.urls import reverse
 from django.utils import timezone
 
 from .models import Stats
-
-
-API_PREFIX = reverse("api-root")
 
 
 def stats_middleware(get_response):
     def middleware(request):
         response = get_response(request)
 
-        if not request.path.startswith(API_PREFIX):
+        if not request.path.startswith("/api"):
             return response
 
         # only update the stats for API access


### PR DESCRIPTION
API v2 needs to exist alongside v1 while we transition over to it.  This removes the reliance on a named URL for that prefix, ready for the versioned URLs to arrive.

Refs #186 