### PR TITLE
Fix Workspace Detail for Anon Users

### DIFF
--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -52,6 +52,7 @@
   </div>
 </div>
 
+{% if request.user.is_authenticated %}
 {% if not actions %}
 <div class="my-5 text-center">
   <p>
@@ -195,5 +196,6 @@
 
   </div>
 </div>
+{% endif %}
 {% endif %}
 {% endblock content %}

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -15,6 +15,7 @@
         <a class="btn btn-primary" href="{% url 'workspace-logs' name=workspace.name %}">
           Logs
         </a>
+        {% if request.user.is_authenticated %}
         <a
           class="btn btn-primary"
           data-toggle="collapse"
@@ -24,10 +25,11 @@
           aria-controls="details">
           Details
         </a>
+        {% endif %}
       </div>
     </div>
 
-    <div id="details" class="collapse">
+    <div id="details"{% if request.user.is_authenticated %} class="collapse"{% endif %}>
 
       <p>
         <strong>Repo:</strong>


### PR DESCRIPTION
This hides the JobRequest creation form (ie the Actions list) when a User is anonymous.  It also expands the details section so the page isn't quite so bare when in this state.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/Jruqknoe/Image%202020-11-19%20at%203.15.55%20pm.png?v=1a6bf038b9bd8346dba91ddfe21f7d93)

Fixes #217 