### PR TITLE
Catch invalid YAML

### DIFF
--- a/jobserver/project.py
+++ b/jobserver/project.py
@@ -13,7 +13,10 @@ def get_actions(repo, branch):
     if content is None:
         return []
 
-    project = load_yaml(content)
+    try:
+        project = load_yaml(content)
+    except yaml.scanner.ScannerError:
+        return []
 
     for action, children in project["actions"].items():
         needs = children.get("needs", []) if children else []

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -58,9 +58,11 @@
 {% if not actions %}
 <div class="my-5 text-center">
   <p>
-    It looks like the branch <code>{{ branch }}</code> doesn't have a <code>project.yaml</code>.
+    It looks like the branch <code>{{ branch }}</code> doesn't have a
+    <code>project.yaml</code> or possibly your <code>project.yaml</code> is
+    invalid.
   </p>
-  <p>Create one and reload this page to continue.</p>
+  <p>Create a valid one and reload this page to continue.</p>
 </div>
 {% else %}
 <div class="row job-create">

--- a/tests/jobserver/test_project.py
+++ b/tests/jobserver/test_project.py
@@ -10,6 +10,19 @@ def test_get_actions_no_project_yaml():
     assert output == []
 
 
+def test_get_actions_invalid_yaml():
+    dummy_yaml = """
+    <<<<<<< HEAD
+    actions:
+      frobnicate:
+    """
+
+    with patch("jobserver.project.get_file", lambda r, b: dummy_yaml):
+        output = list(get_actions("test", "master"))
+
+    assert output == []
+
+
 def test_get_actions_success():
     dummy_yaml = """
     actions:


### PR DESCRIPTION
[Sentry](https://sentry.io/organizations/ebm-datalab/issues/2042192762/?project=5443358&query=is%3Aunresolved)

When parsing invalid YAML we get an error and return a 500 to the user.  This catches that error and updates the message we show users when we can't find or parse their `project.yaml`.