### PR TITLE
Set a Helpful Actions Error Message

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -20,7 +20,11 @@ class JobRequestCreateForm(forms.ModelForm):
         #  add action field based on the actions passed in
         choices = [(a, a) for a in actions]
         self.fields["requested_actions"] = forms.MultipleChoiceField(
-            choices=choices, widget=forms.CheckboxSelectMultiple
+            choices=choices,
+            widget=forms.CheckboxSelectMultiple,
+            error_messages={
+                "required": "Please select at least one of the Actions listed above."
+            },
         )
 
 


### PR DESCRIPTION
This sets a more meaningful error message when a User hasn't selected any Actions when creating a `JobRequest`.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/ApuG1dbB/Image%202020-11-25%20at%2010.08.48%20am.jpg?v=550c0be3ba5d22c6312e2018eda28499)

Fixes #227 