### PR TITLE
Explain Missing Repo When Creating a Workspace

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -51,7 +51,11 @@ class WorkspaceCreateForm(forms.ModelForm):
         self.repos_with_branches = repos_with_branches
 
         choices = [(r["url"], r["name"]) for r in self.repos_with_branches]
-        self.fields["repo"] = forms.ChoiceField(label="Repo", choices=choices)
+        self.fields["repo"] = forms.ChoiceField(
+            label="Repo",
+            choices=choices,
+            help_text="If your repo doesn't show up here, reach out to the OpenSAFELY team on Slack.",
+        )
 
     def clean_branch(self):
         repo_url = self.cleaned_data["repo"]


### PR DESCRIPTION
This sets help text under the Repos dropdown when creating a Workspace to help explain why someone's repo might not be there.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/6quxW9zA/Image%202020-11-25%20at%204.04.25%20pm.jpg?v=ee1916c48aae2b856514472e630d499c)

I toyed with more extensive language around what team the repo needed to be in under our GitHub Org but decided to keep it short and sweet since they wouldn't be able to self-service the fix anyway.

Fixes #230 