### PR TITLE
Ensure run_all Action

### DIFF
--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -242,6 +242,13 @@ class WorkspaceDetail(CreateView):
 
         self.actions = sorted(actions_with_statues, key=operator.itemgetter("name"))
 
+        # ensure there's a run_all action
+        action_names = [a["name"] for a in self.actions]
+        if "run_all" not in action_names:
+            self.actions.append(
+                {"name": "run_all", "needs": sorted(action_names), "status": "-"}
+            )
+
         return super().dispatch(request, *args, **kwargs)
 
     @transaction.atomic


### PR DESCRIPTION
This ensures there's always a `run_all` action.  When adding it to the list this takes the somewhat blunt approach and treats every other action as a direct "dependency" since this is only used in the UI for the "Needs" accordion.

Fixes #234 