### PR TITLE
Redirect to a Workspace Logs

### DIFF
--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -259,7 +259,7 @@ class WorkspaceDetail(CreateView):
                 force_run=True,
             )
 
-        return redirect("job-list")
+        return redirect("workspace-logs", name=self.workspace.name)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -486,7 +486,7 @@ def test_workspacedetail_post_success(rf):
         response = WorkspaceDetail.as_view()(request, name=workspace.name)
 
     assert response.status_code == 302, response.context_data["form"].errors
-    assert response.url == reverse("job-list")
+    assert response.url == reverse("workspace-logs", kwargs={"name": workspace.name})
 
     job_request = JobRequest.objects.first()
     assert job_request.created_by == user


### PR DESCRIPTION
This redirects a User to the Logs page of a Workspace after they create a JobRequest.

Fixes #238 