### PR TITLE
Replace Rather than Recreate Jobs

### DIFF
--- a/tests/jobserver/test_api.py
+++ b/tests/jobserver/test_api.py
@@ -238,7 +238,7 @@ def test_jobapiupdate_mixture(api_rf, freezer):
     job2, job3 = jobs
 
     # succeeded
-    assert job2.pk != job1.pk
+    assert job2.pk == job1.pk
     assert job2.identifier == "job1"
     assert job2.started_at == timezone.now() - timedelta(minutes=1)
     assert job2.updated_at == timezone.now()


### PR DESCRIPTION
This changes the way we create Jobs in the v2 API.  Currently we delete all Jobs for a given JobRequest, then create a brand new set based on the incoming payload.  This has the advantage of being very simple.  However, it has made our PKs spiral upwards for no particularly good reason.  This change instead groups the incoming Jobs by their JobRequest identifier and then processes them to delete/create/update as appropriate.

The longer term fix to this is to replace `Job.pk` with `Job.identifier`, but in order to that we need to remove all Jobs created via the v1 API (and from before even that!).  Since we only deployed v2 earlier this week I'd like to let it get a bit more use before I start deleting our historical Jobs (or modify them with unique identifiers).

Ref #244