### PR TITLE
Handle needs key being Empty

### DIFF
--- a/jobserver/project.py
+++ b/jobserver/project.py
@@ -20,4 +20,9 @@ def get_actions(repo, branch):
 
     for action, children in project["actions"].items():
         needs = children.get("needs", []) if children else []
+
+        # handle needs being defined but empty
+        if needs is None:
+            needs = []
+
         yield {"name": action, "needs": sorted(needs)}

--- a/tests/jobserver/test_project.py
+++ b/tests/jobserver/test_project.py
@@ -3,6 +3,19 @@ from unittest.mock import patch
 from jobserver.project import get_actions
 
 
+def test_get_actions_empty_needs():
+    dummy_yaml = """
+    actions:
+      frobnicate:
+        needs:
+    """
+
+    with patch("jobserver.project.get_file", lambda r, b: dummy_yaml):
+        output = list(get_actions("test", "master"))
+
+    assert output == [{"name": "frobnicate", "needs": []}]
+
+
 def test_get_actions_no_project_yaml():
     with patch("jobserver.project.get_file", lambda r, b: None):
         output = list(get_actions("test", "master"))


### PR DESCRIPTION
[Sentry](https://sentry.io/organizations/ebm-datalab/issues/2072073412/?project=5443358)

When the `needs` key is defined without content it arrives as None, this handles that case.