### PR TITLE
Remove Custom Job.save Paths

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -1,8 +1,6 @@
 import base64
-import datetime
 import secrets
 
-import pytz
 import requests
 import structlog
 from django.contrib.auth.models import AbstractUser
@@ -110,13 +108,6 @@ class Job(models.Model):
         return Runtime(int(hours), int(minutes), int(seconds))
 
     def save(self, *args, **kwargs):
-        if self.started and not self.started_at:
-            self.started_at = datetime.datetime.now(tz=pytz.UTC)
-
-        if self.status_code is not None and not self.completed_at:
-            if self.started:
-                self.completed_at = datetime.datetime.now(tz=pytz.UTC)
-
         super().save(*args, **kwargs)
 
         self.notify_callback_url()

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -147,53 +147,6 @@ def test_job_runtime_not_started():
 
 
 @pytest.mark.django_db
-def test_job_save(freezer):
-    job = JobFactory()
-
-    assert job.started_at is None
-    assert job.completed_at is None
-
-    job.started = True
-    job.status_code = 1
-    job.save()
-
-    assert job.started_at == timezone.now()
-    assert job.completed_at == timezone.now()
-
-
-@pytest.mark.django_db
-def test_job_save_not_started():
-    job = JobFactory()
-
-    assert not job.started
-    assert not job.started_at
-    assert not job.completed_at
-
-    job.status_code = 1
-    job.save()
-
-    assert job.status_code == 1
-
-
-@pytest.mark.django_db
-def test_job_save_with_started_at_set(freezer):
-    job = JobFactory()
-
-    assert job.started_at is None
-    assert job.completed_at is None
-
-    start = timezone.now() - timedelta(hours=1)
-
-    job.started = True
-    job.started_at = start
-    job.status_code = 1
-    job.save()
-
-    assert job.started_at == start
-    assert job.completed_at == timezone.now()
-
-
-@pytest.mark.django_db
 def test_job_str():
     job = JobFactory(action="Run")
 


### PR DESCRIPTION
This removes the field modifying parts of Job's custom `.save()`.  Now that job-runner is setting these fields we can rely on them being in the correct state.

Ref #254 