### PR TITLE
Sort Actions by project.yaml Order

### DIFF
--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -1,5 +1,3 @@
-import operator
-
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
@@ -235,13 +233,11 @@ class WorkspaceDetail(CreateView):
         # project.yaml for the User to pick from
         actions = get_actions(self.workspace.repo_name, self.workspace.branch)
 
-        actions_with_statues = []
+        self.actions = []
         prefetch_related_objects([self.workspace], "job_requests__jobs")
         for action in actions:
             status = self.workspace.get_latest_status_for_action(action["name"])
-            actions_with_statues.append(action | {"status": status})
-
-        self.actions = sorted(actions_with_statues, key=operator.itemgetter("name"))
+            self.actions.append(action | {"status": status})
 
         # ensure there's a run_all action
         action_names = [a["name"] for a in self.actions]

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -441,8 +441,8 @@ def test_workspacedetail_get_success(rf):
     assert response.status_code == 200
 
     assert response.context_data["actions"] == [
-        {"name": "run_all", "needs": ["twiddle"], "status": "-"},
         {"name": "twiddle", "needs": [], "status": "-"},
+        {"name": "run_all", "needs": ["twiddle"], "status": "-"},
     ]
 
     assert response.context_data["branch"] == workspace.branch


### PR DESCRIPTION
This stops the sorting of actions listed when creating a `JobRequest` so they retain their ordering from project.yaml.

With [carehomes](https://github.com/opensafely/carehomes-research/blob/master/project.yaml):

![](https://p198.p4.n0.cdn.getcloudapp.com/items/9Zu0XWv6/Image%202020-12-07%20at%204.44.36%20pm.jpg?v=686030624dbef934db30840069c21285)

Fixes #267 