### PR TITLE
Respect line breaks and spaces in status messages

### DIFF
--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -24,7 +24,7 @@
       <div>
         <strong>Status Message:</strong>
         {% if job.status_message %}
-        <code>{{ job.status_message }}</code>
+        <pre>{{ job.status_message }}</pre>
         {% else %}-{% endif %}
       </div>
 


### PR DESCRIPTION
This switches the wrapping element of `Job.status_message` from `<code>` to `<pre>` so the formatting in that string appear in the UI.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/Z4uqqdwX/Image%202020-12-09%20at%209.16.46%20am.jpg?v=a1f8337d2e4a3bda90c41dead4345d94)

(not a great example but I don't have any YAML failures locally!)

Fixes #271 