### PR TITLE
Bump sqlite3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY requirements.txt .
 RUN pip install --requirement requirements.txt
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y sqlite3=3.27.2-3 && \
+    apt-get install --no-install-recommends -y sqlite3=3.27.2-3+deb10u1 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This bumps the version of sqlite3 in our Docker image, since the previous version (`3.27.2-3`) no longer exists.

@bloodearnest – am I doing this right?  I've not pinned apt packages before (hadolint told me to), but I assume something changed with `python:3.9-buster` to make this happen?