### PR TITLE
Display YAML Parsing Errors

### DIFF
--- a/jobserver/project.py
+++ b/jobserver/project.py
@@ -7,16 +7,17 @@ def load_yaml(content):
     return yaml.safe_load(content)
 
 
-def get_actions(repo, branch):
+def get_actions(repo, branch, status_lut):
     """Get actions from project.yaml for this Workspace"""
     content = get_file(repo, branch)
     if content is None:
-        return []
+        raise Exception("Could not find project.yaml")
 
-    try:
-        project = load_yaml(content)
-    except yaml.scanner.ScannerError:
-        return []
+    project = load_yaml(content)
+
+    # ensure there's always a run_all action
+    if "run_all" not in project["actions"]:
+        project["actions"]["run_all"] = {"needs": list(project["actions"].keys())}
 
     for action, children in project["actions"].items():
         needs = children.get("needs", []) if children else []
@@ -25,4 +26,7 @@ def get_actions(repo, branch):
         if needs is None:
             needs = []
 
-        yield {"name": action, "needs": sorted(needs)}
+        # get latest status for this action from the lookup table
+        status = status_lut.get(action, "-")
+
+        yield {"name": action, "needs": sorted(needs), "status": status}

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -55,16 +55,20 @@
 </div>
 
 {% if request.user.is_authenticated %}
-{% if not actions %}
-<div class="my-5 text-center">
-  <p>
-    It looks like the branch <code>{{ branch }}</code> doesn't have a
-    <code>project.yaml</code> or possibly your <code>project.yaml</code> is
-    invalid.
-  </p>
-  <p>Create a valid one and reload this page to continue.</p>
+{% if actions_error %}
+<div class="row">
+  <div class="col-lg-8 offset-lg-2 my-5">
+
+    <p>An error occurred while trying to parse your <code>project.yaml</code>:</p>
+
+    <pre class="text-left">{{ actions_error }}</pre>
+
+    <p>Fix the error above and reload this page to continue.</p>
+  </div>
 </div>
-{% else %}
+{% endif %}
+
+{% if actions %}
 <div class="row job-create">
   <div class="col-lg-8 offset-lg-2">
 


### PR DESCRIPTION
This reworks the `get_actions()` function to raise exceptions on errors so we can bubble the `YamlScanner` and fetching-from-github exceptions up to the UI and display them to the User.

This required building a lookup table of action -> status to pass into `get_actions()` so that replaced `Workspace.get_latest_status_for_action()`.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/ApuGGRdB/Image%202020-12-09%20at%204.57.50%20pm.jpg?v=94d75f73d449ee7e76bd1c0f3fdfd432)

Fixes #270 