### PR TITLE
Use First Configured Backend

### DIFF
--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -7,7 +7,7 @@ from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.views.generic import CreateView, DetailView, ListView, TemplateView, View
 
-from .backends import TPP, show_warning
+from .backends import backends, show_warning
 from .forms import JobRequestCreateForm, WorkspaceCreateForm
 from .github import get_branch_sha, get_repos_with_branches
 from .models import Job, JobRequest, Stats, User, Workspace
@@ -253,10 +253,15 @@ class WorkspaceDetail(CreateView):
     def form_valid(self, form):
         sha = get_branch_sha(self.workspace.repo_name, self.workspace.branch)
 
+        # Pick a backend.
+        #  We're only configuring one backend in an installation currently.
+        # Rely on that for now.
+        backend = list(backends)[0]
+
         JobRequest.objects.create(
             workspace=self.workspace,
             created_by=self.request.user,
-            backend=TPP,
+            backend=backend,
             sha=sha,
             **form.cleaned_data,
         )

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -462,7 +462,9 @@ def test_workspacedetail_get_success(rf):
 
 
 @pytest.mark.django_db
-def test_workspacedetail_post_success(rf):
+def test_workspacedetail_post_success(rf, monkeypatch):
+    monkeypatch.setattr("jobserver.views.backends", ["the-backend"])
+
     workspace = WorkspaceFactory()
     user = UserFactory()
 
@@ -487,7 +489,7 @@ def test_workspacedetail_post_success(rf):
     job_request = JobRequest.objects.first()
     assert job_request.created_by == user
     assert job_request.workspace == workspace
-    assert job_request.backend == "tpp"
+    assert job_request.backend == "the-backend"
     assert job_request.requested_actions == ["twiddle"]
     assert job_request.sha == "abc123"
     assert not job_request.jobs.exists()


### PR DESCRIPTION
We're not showing a control to pick the backend for JobRequests yet but
we do change backend for local development so pick the first one
configured for now.