### PR TITLE
Improve Job Detail Page

### DIFF
--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -24,7 +24,7 @@
       <div>
         <strong>Status Message:</strong>
         {% if job.status_message %}
-        <code>{{ job.status_message }}</code>
+        <pre>{{ job.status_message }}</pre>
         {% else %}-{% endif %}
       </div>
 

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -18,10 +18,6 @@
       </div>
 
       <div>
-        <strong>Started:</strong> {{ job.started }}
-      </div>
-
-      <div>
         <strong>Status Message:</strong>
         {% if job.status_message %}
         <pre>{{ job.status_message }}</pre>


### PR DESCRIPTION
This wraps the `Job.status_message` field in a `<pre>` instead of a `<code>` to maintain whitespace and newlines, and removes the disused `Job.started` field we removed in #265.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/v1u40bJo/Image%202020-12-15%20at%209.42.17%20am.jpg?v=8d94ddf5a23e6d89f92983e05d9ef58d)

Fixes #271 
Ref #254 