### PR TITLE
Selectively Load Actions

### DIFF
--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -229,6 +229,12 @@ class WorkspaceDetail(CreateView):
         except Workspace.DoesNotExist:
             return redirect("/")
 
+        if not request.user.is_authenticated:
+            # short-circuit for logged out users to avoid the hop to grab
+            # actions from GitHub
+            self.actions = []
+            return super().dispatch(request, *args, **kwargs)
+
         action_status_lut = self.workspace.get_action_status_lut()
 
         # build actions as list or render the exception to the page


### PR DESCRIPTION
This stops the loading of a project.yaml's actions from GitHub when a User is not logged in, avoiding any penalty to the page load for those users.