### PR TITLE
Fix JobRequestList Status Filtering

### DIFF
--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -140,17 +140,15 @@ def test_jobrequestlist_filters_exist(rf):
 
 @pytest.mark.django_db
 def test_jobrequestlist_filter_by_status(rf):
-    job_request1 = JobRequestFactory()
-    JobFactory(job_request=job_request1)
+    JobFactory(job_request=JobRequestFactory(), status="failed")
 
-    job_request2 = JobRequestFactory()
-    JobFactory.create_batch(2, job_request=job_request2, status="succeeded")
+    JobFactory(job_request=JobRequestFactory(), status="succeeded")
 
     # Build a RequestFactory instance
     request = rf.get("/?status=succeeded")
     response = JobRequestList.as_view()(request)
 
-    assert len(response.context_data["object_list"]) == 1
+    assert len(response.context_data["page_obj"]) == 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Django's pagination (provided by MultipleObjectMixin [1]) constructs the
Paginator instance as part of it's get_context_data so the filtered
object_list needed to be passed to that.

[1]: https://github.com/django/django/blob/3.1/django/views/generic/list.py#L113-L136