### PR TITLE
Hide API URL from WorkspaceDetail Template

### DIFF
--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -220,6 +220,6 @@
 {% endblock content %}
 
 {% block extra_js %}
-<div id="apiUrl">{{ workspace.get_statuses_url }}</div>
+<div id="apiUrl" class="d-none">{{ workspace.get_statuses_url }}</div>
 <script type="text/javascript" src="{% static 'js/workspace_detail.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION
This hides the API URL we're exposing to the Javascript code.

Oops 😬 