### PR TITLE
Limit authentications to OpenSAFELY GitHub Org

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -144,16 +144,16 @@ LOGGING = logging_config_dict
 
 # Auth
 AUTHENTICATION_BACKENDS = [
-    "social_core.backends.github.GithubOAuth2",
+    "jobserver.github.GithubOrganizationOAuth2",
     "django.contrib.auth.backends.ModelBackend",
 ]
 AUTH_USER_MODEL = "jobserver.User"
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
-LOGIN_URL = reverse_lazy("social:begin", kwargs={"backend": "github"})
-SOCIAL_AUTH_GITHUB_KEY = env.str("SOCIAL_AUTH_GITHUB_KEY", default=None)
-SOCIAL_AUTH_GITHUB_SECRET = env.str("SOCIAL_AUTH_GITHUB_SECRET", default=None)
-SOCIAL_AUTH_GITHUB_SCOPE = ["user:email"]
+LOGIN_URL = reverse_lazy("social:begin", kwargs={"backend": "github-org"})
+SOCIAL_AUTH_GITHUB_ORG_KEY = env.str("SOCIAL_AUTH_GITHUB_KEY", default=None)
+SOCIAL_AUTH_GITHUB_ORG_SECRET = env.str("SOCIAL_AUTH_GITHUB_SECRET", default=None)
+SOCIAL_AUTH_GITHUB_ORG_SCOPE = ["user:email"]
 
 
 # Messages

--- a/jobserver/templates/base.html
+++ b/jobserver/templates/base.html
@@ -41,7 +41,7 @@
 
         <div class="navbar-nav nav-item">
           {% if not user.is_authenticated %}
-          <a class="nav-link" href="{% url "social:begin" "github" %}?next={{ request.path }}">Login</a>
+          <a class="nav-link" href="{% url "social:begin" "github-org" %}?next={{ request.path }}">Login</a>
           {% else %}
           <a class="nav-link" href="{% url 'logout' %}">Logout</a>
           {% endif %}

--- a/tests/jobserver/test_github.py
+++ b/tests/jobserver/test_github.py
@@ -1,6 +1,14 @@
+import pytest
+import requests
 import responses
+from social_core.exceptions import AuthFailed
 
-from jobserver.github import get_branch_sha, get_file, get_repos_with_branches
+from jobserver.github import (
+    GithubOrganizationOAuth2,
+    get_branch_sha,
+    get_file,
+    get_repos_with_branches,
+)
 
 
 @responses.activate
@@ -101,3 +109,63 @@ def test_get_repos_with_branches():
     assert len(output) == 1
     assert output[0]["name"] == "test-repo"
     assert output[0]["branches"][0] == "branch1"
+
+
+@responses.activate
+def test_githuborganizationoauth2_user_data_404():
+    expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
+    responses.add(responses.GET, url=expected_url, status=404)
+
+    class DummyBackend(GithubOrganizationOAuth2):
+        def _user_data(*args, **kwargs):
+            return {"email": "test-email", "login": "test-username"}
+
+    with pytest.raises(AuthFailed, match="User doesn't belong to the organization"):
+        DummyBackend().user_data("access-token")
+
+
+@responses.activate
+def test_githuborganizationoauth2_user_data_302():
+    expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
+    responses.add(responses.GET, url=expected_url, status=302)
+
+    class DummyBackend(GithubOrganizationOAuth2):
+        def _user_data(*args, **kwargs):
+            return {"email": "test-email", "login": "test-username"}
+
+    DummyBackend().user_data("access-token")
+
+
+@responses.activate
+def test_githuborganizationoauth2_user_data_204():
+    expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
+    responses.add(responses.GET, url=expected_url, status=204)
+
+    class DummyBackend(GithubOrganizationOAuth2):
+        def _user_data(*args, **kwargs):
+            return {"email": "test-email", "login": "test-username"}
+
+    DummyBackend().user_data("access-token")
+
+    assert len(responses.calls) == 1
+
+
+def test_githuborganizationoauth2_user_data_204_via_error():
+    """
+    Check an HTTPError with response.status_code == 204 doesn't throw an error
+
+    GithubMemberOAuth2 has a check to confirm the status_code of an HTTPError
+    isn't 204.  Since raise_for_status only fires on unsuccessful codes (<400)
+    it's tricky to test this condition!
+    """
+
+    class DummyBackend(GithubOrganizationOAuth2):
+        def _user_data(self, *args, **kwargs):
+            return {"email": "test-email", "login": "test-username"}
+
+        def request(self, *args, **kwargs):
+            response = requests.Response()
+            response.status_code = 204
+            raise requests.exceptions.HTTPError(response=response)
+
+    DummyBackend().user_data("access-token")


### PR DESCRIPTION
This limits successful authentications to the OpenSAFELY GitHub Org.  As the custom backend class explains I had to reimplement the provided GitHub backend classes from social-core to let us use our PAT instead of the User's OAuth token.