### PR TITLE
Improve GitHub Org Check

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -140,11 +140,15 @@ class GithubOrganizationOAuth2(GithubOAuth2):
         headers = {"Authorization": f"token {TOKEN}"}
 
         try:
-            self.request(f.url, headers=headers)
-        except requests.HTTPError as err:
-            # if the user is a member of the organization, response code
-            # will be 204, see http://bit.ly/ZS6vFl
-            if err.response.status_code != 204:
-                raise AuthFailed(self, "User doesn't belong to the organization")
+            r = self.request(f.url, headers=headers)
+        except requests.HTTPError as e:
+            # ignore unsuccessful responses, they're all handled in the
+            # conditional below
+            r = e.response
+
+        # The member-of-an-org endpoint returns a 204 on success, any other
+        # status code is a failure here.
+        if r.status_code != 204:
+            raise AuthFailed(self, "User doesn't belong to the organization")
 
         return user_data

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -126,6 +126,7 @@ class GithubOrganizationOAuth2(GithubOAuth2):
         """
         user_data = super().user_data(access_token, *args, **kwargs)
 
+        # https://docs.github.com/en/free-pro-team@latest/rest/reference/orgs#check-organization-membership-for-a-user
         f = furl(BASE_URL)
         f.path.segments += [
             "orgs",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,27 @@
 import pytest
 
+from jobserver.github import GithubOrganizationOAuth2
+
 
 @pytest.fixture
 def api_rf():
     from rest_framework.test import APIRequestFactory
 
     return APIRequestFactory()
+
+
+@pytest.fixture
+def dummy_backend():
+    """
+    Create a DummyBackend instance
+
+    Our GithubOrganizationOAuth2 backend will be instantiated in practice.
+    This allows us to test instances of it with _user_data() set (as it would
+    be in practice).
+    """
+
+    class DummyBackend(GithubOrganizationOAuth2):
+        def _user_data(self, *args, **kwargs):
+            return {"email": "test-email", "login": "test-username"}
+
+    return DummyBackend()

--- a/tests/jobserver/test_github.py
+++ b/tests/jobserver/test_github.py
@@ -2,12 +2,7 @@ import pytest
 import responses
 from social_core.exceptions import AuthFailed
 
-from jobserver.github import (
-    GithubOrganizationOAuth2,
-    get_branch_sha,
-    get_file,
-    get_repos_with_branches,
-)
+from jobserver.github import get_branch_sha, get_file, get_repos_with_branches
 
 
 @responses.activate
@@ -111,41 +106,28 @@ def test_get_repos_with_branches():
 
 
 @responses.activate
-def test_githuborganizationoauth2_user_data_204():
+def test_githuborganizationoauth2_user_data_204(dummy_backend):
     expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
     responses.add(responses.GET, url=expected_url, status=204)
 
-    class DummyBackend(GithubOrganizationOAuth2):
-        def _user_data(*args, **kwargs):
-            return {"email": "test-email", "login": "test-username"}
-
-    # just want to check this doesn't raise an exception here
-    DummyBackend().user_data("access-token")
+    dummy_backend.user_data("access-token")
 
     assert len(responses.calls) == 1
 
 
 @responses.activate
-def test_githuborganizationoauth2_user_data_302():
+def test_githuborganizationoauth2_user_data_302(dummy_backend):
     expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
     responses.add(responses.GET, url=expected_url, status=302)
 
-    class DummyBackend(GithubOrganizationOAuth2):
-        def _user_data(*args, **kwargs):
-            return {"email": "test-email", "login": "test-username"}
-
     with pytest.raises(AuthFailed, match="User doesn't belong to the organization"):
-        DummyBackend().user_data("access-token")
+        dummy_backend.user_data("access-token")
 
 
 @responses.activate
-def test_githuborganizationoauth2_user_data_404():
+def test_githuborganizationoauth2_user_data_404(dummy_backend):
     expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
     responses.add(responses.GET, url=expected_url, status=404)
 
-    class DummyBackend(GithubOrganizationOAuth2):
-        def _user_data(*args, **kwargs):
-            return {"email": "test-email", "login": "test-username"}
-
     with pytest.raises(AuthFailed, match="User doesn't belong to the organization"):
-        DummyBackend().user_data("access-token")
+        dummy_backend.user_data("access-token")


### PR DESCRIPTION
This documents the endpoint we use to make the Organization check and groups all the status code handling into a single conditional.