### PR TITLE
Change Social Provider Name

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -142,8 +142,16 @@ def get_repos_with_branches():
 class GithubOrganizationOAuth2(GithubOAuth2):
     """Github OAuth2 authentication backend for organizations"""
 
-    name = "github-org"
     no_member_string = "User doesn't belong to the organization"
+
+    # Mirror our initial Social Auth Backend choice (GithubOAuth2) provider's
+    # name because it's simpler than making a migration which modifies the
+    # UserSocialAuth table.  Our jobserver app defines a Custom User Model
+    # which social_django depends on in it's migrations dependency tree
+    # (because it FKs User).  This appears to make migrations hit a catch-22 in
+    # dependency resolution.  Rather than dig through the resolver, this is a
+    # much easier fix.
+    name = "github"
 
     def user_data(self, access_token, *args, **kwargs):
         """

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -150,7 +150,7 @@ AUTHENTICATION_BACKENDS = [
 AUTH_USER_MODEL = "jobserver.User"
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
-LOGIN_URL = reverse_lazy("social:begin", kwargs={"backend": "github-org"})
+LOGIN_URL = reverse_lazy("social:begin", kwargs={"backend": "github"})
 SOCIAL_AUTH_GITHUB_ORG_KEY = env.str("SOCIAL_AUTH_GITHUB_KEY", default=None)
 SOCIAL_AUTH_GITHUB_ORG_SECRET = env.str("SOCIAL_AUTH_GITHUB_SECRET", default=None)
 SOCIAL_AUTH_GITHUB_ORG_SCOPE = ["user:email"]

--- a/jobserver/templates/base.html
+++ b/jobserver/templates/base.html
@@ -41,7 +41,7 @@
 
         <div class="navbar-nav nav-item">
           {% if not user.is_authenticated %}
-          <a class="nav-link" href="{% url "social:begin" "github-org" %}?next={{ request.path }}">Login</a>
+          <a class="nav-link" href="{% url "social:begin" "github" %}?next={{ request.path }}">Login</a>
           {% else %}
           <a class="nav-link" href="{% url 'logout' %}">Logout</a>
           {% endif %}


### PR DESCRIPTION
This changes the social auth provider's name to match our previous provider's name (`github`), allowing us to avoid trying to work out how to migrate the existing database rows.

Ref #294 
Ref #297