### PR TITLE
Remove org suffix from auth settings

### DIFF
--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -151,9 +151,9 @@ AUTH_USER_MODEL = "jobserver.User"
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
 LOGIN_URL = reverse_lazy("social:begin", kwargs={"backend": "github"})
-SOCIAL_AUTH_GITHUB_ORG_KEY = env.str("SOCIAL_AUTH_GITHUB_KEY", default=None)
-SOCIAL_AUTH_GITHUB_ORG_SECRET = env.str("SOCIAL_AUTH_GITHUB_SECRET", default=None)
-SOCIAL_AUTH_GITHUB_ORG_SCOPE = ["user:email"]
+SOCIAL_AUTH_GITHUB_KEY = env.str("SOCIAL_AUTH_GITHUB_KEY", default=None)
+SOCIAL_AUTH_GITHUB_SECRET = env.str("SOCIAL_AUTH_GITHUB_SECRET", default=None)
+SOCIAL_AUTH_GITHUB_SCOPE = ["user:email"]
 
 
 # Messages


### PR DESCRIPTION
Fix social auth settings for backend name change.