### PR TITLE
Explain run_all Semantics

### DIFF
--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -163,7 +163,14 @@
         </div>
 
         <small id="actions_help_block" class="form-text text-muted">
-          Selecting an Action will run it, regardless of its previous state or outputs.
+          <p>Selecting an Action will run it, regardless of its previous state or outputs.</p>
+
+          <p>
+            Selecting "run_all" will run any Action which has yet to complete.
+            Previously successful actions are skipped. A previously failed
+            action will cause "run_all" to refuse to run.  You can override
+            this functionality by selecting "force run dependencies" below.
+          </p>
         </small>
 
         {% if form.requested_actions.errors %}


### PR DESCRIPTION
This adds some more help text under the actions list to explain how the `run_all` actions.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/GGu2J2JY/d716b851-a3ee-4086-9552-7011167711e8.jpg?v=f7a15eee7b646b073d73dcc75bc5b971)

Fixes #276 