### PR TITLE
Fix Duplicate Migration Names

### DIFF
--- a/jobserver/migrations/0055_add_workspace_is_archived.py
+++ b/jobserver/migrations/0055_add_workspace_is_archived.py
@@ -6,7 +6,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("jobserver", "0053_add_backend_auth_token"),
+        ("jobserver", "0054_remove_blankability_from_job_timestamp_fields"),
     ]
 
     operations = [


### PR DESCRIPTION
This fixes the migration name of one of the duplicate migration files which came about because I made #305 and #307 in parallel.