### PR TITLE
Expose Missing Branch as an Error State

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -13,7 +13,7 @@ TOKEN = env.str("GITHUB_TOKEN")
 USER_AGENT = "OpenSAFELY Jobs"
 
 
-def get_branch_sha(repo, branch):
+def get_branch(repo, branch):
     f = furl(BASE_URL)
     f.path.segments += [
         "repos",
@@ -29,9 +29,22 @@ def get_branch_sha(repo, branch):
         "User-Agent": "OpenSAFELY Jobs",
     }
     r = requests.get(f.url, headers=headers)
+
+    if r.status_code == 404:
+        return
+
     r.raise_for_status()
 
-    return r.json()["commit"]["sha"]
+    return r.json()
+
+
+def get_branch_sha(repo, branch):
+    branch = get_branch(repo, branch)
+
+    if branch is None:
+        return
+
+    return branch["commit"]["sha"]
 
 
 def get_file(repo, branch):

--- a/jobserver/project.py
+++ b/jobserver/project.py
@@ -1,6 +1,6 @@
 import yaml
 
-from .github import get_file
+from .github import get_branch, get_file
 
 
 def load_yaml(content):
@@ -11,6 +11,9 @@ def get_actions(repo, branch, status_lut):
     """Get actions from project.yaml for this Workspace"""
     content = get_file(repo, branch)
     if content is None:
+        if get_branch(repo, branch) is None:
+            raise Exception(f"Missing branch: '{branch}'")
+
         raise Exception("Could not find project.yaml")
 
     project = load_yaml(content)

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -90,7 +90,23 @@
 
     <pre class="text-left">{{ actions_error }}</pre>
 
-    <p>Fix the error above and reload this page to continue.</p>
+    <p>
+      To run actions for this Workspace please fix the error above and reload
+      this page to continue.
+    </p>
+
+    <p>
+      If the branch no longer exists you will need to set up a new workspace.
+      Previous jobs in this workspace are still available via the Logs button.
+    </p>
+
+    {% if not workspace.is_archived %}
+    <p>
+      If you are done with this Workspace's branch you can also Archive it to
+      stop it appearing on the homepage list.
+    </p>
+    {% endif %}
+
   </div>
 </div>
 {% endif %}

--- a/tests/jobserver/test_project.py
+++ b/tests/jobserver/test_project.py
@@ -23,10 +23,17 @@ def test_get_actions_empty_needs():
     assert output == expected
 
 
+def test_get_actions_no_branch():
+    with patch("jobserver.project.get_file", lambda r, b: None), patch(
+        "jobserver.project.get_branch", lambda r, b: None
+    ), pytest.raises(Exception, match="Missing branch: 'master'"):
+        list(get_actions("test", "master", {}))
+
+
 def test_get_actions_no_project_yaml():
-    with patch("jobserver.project.get_file", lambda r, b: None), pytest.raises(
-        Exception, match="Could not find project.yaml"
-    ):
+    with patch("jobserver.project.get_file", lambda r, b: None), patch(
+        "jobserver.project.get_branch", lambda r, b: True
+    ), pytest.raises(Exception, match="Could not find project.yaml"):
         list(get_actions("test", "master", {}))
 
 


### PR DESCRIPTION
This surfaces a Workspace's branch missing on GitHub as a first class error state to the UI.  When we can't get a project.yaml from GitHub we check for the presence of the branch (so the extra request is only triggered when there's already no actions to show) and if it's missing bubble that up to the UI.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/YEuQbNwp/4e12e456-9623-4cff-9ec4-bc3659a14793.jpg?v=23c2b8d320e6740ec9d47fe074bdb1c3)

Fixes #314 