### PR TITLE
View Backend Stats

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -276,6 +276,15 @@ class Stats(models.Model):
     class Meta:
         unique_together = ["backend", "url"]
 
+    def __str__(self):
+        backend = self.backend.name
+        last_seen = (
+            self.api_last_seen.strftime("%Y-%m-%d %H:%M:%S")
+            if self.api_last_seen
+            else "never"
+        )
+        return f"{backend} | {last_seen} | {self.url}"
+
 
 class User(AbstractUser):
     @property

--- a/jobserver/templates/status.html
+++ b/jobserver/templates/status.html
@@ -7,34 +7,43 @@
 
     <h1 class="mb-4">Runner Statuses</h1>
 
-    {% for backend in backends %}
+    <div class="row">
 
-    <h2>
-      {{ backend.name }}
-      {% if backend.show_warning %}
-      <span
-        id="warning-tooltip"
-        class="text-warning"
-        data-toggle="tooltip"
-        data-placement="bottom"
-        title="{{ backend.name }} runner not seen for at least 5 mins"
-        >
-        ⚠️
-      </span>
-      {% endif %}
-    </h2>
+      {% for backend in backends %}
+      <div class="col-lg-6 mb-5">
 
-    <p>
-      <strong>Runner Last Seen:</strong> {{ backend.last_seen }}
-    </p>
+        <h2>
+          {{ backend.name }}
+          {% if backend.show_warning %}
+          <span
+            id="warning-tooltip"
+            class="text-warning"
+            data-toggle="tooltip"
+            data-placement="bottom"
+            title="{{ backend.name }} runner not seen for at least 5 mins"
+            >
+            ⚠️
+          </span>
+          {% endif %}
+        </h2>
 
-    <p>
-      <strong>Unacked Jobs:</strong> {{ backend.queue.unacked }}
-    </p>
+        <p>
+          <strong>Runner Last Seen:</strong> {{ backend.last_seen }}
+        </p>
 
-    <p>
-      <strong>Acked Jobs:</strong> {{ backend.queue.acked }}
-    </p>
-    {% endfor %}
+        <p>
+          <strong>Unacked Jobs:</strong> {{ backend.queue.unacked }}
+        </p>
 
+        <p>
+          <strong>Acked Jobs:</strong> {{ backend.queue.acked }}
+        </p>
+
+      </div>
+      {% endfor %}
+
+    </div>
+
+  </div>
+</div>
 {% endblock %}

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -12,7 +12,7 @@ from django.views.generic import CreateView, DetailView, ListView, TemplateView,
 from .backends import show_warning
 from .forms import JobRequestCreateForm, WorkspaceCreateForm
 from .github import get_branch_sha, get_repos_with_branches
-from .models import Backend, Job, JobRequest, Stats, User, Workspace
+from .models import Backend, Job, JobRequest, User, Workspace
 from .project import get_actions
 
 
@@ -186,33 +186,35 @@ class JobRequestZombify(View):
 
 class Status(View):
     def get(self, request, *args, **kwargs):
-        acked = JobRequest.objects.acked().count()
-        unacked = JobRequest.objects.unacked().count()
-
-        try:
-            last_seen = Stats.objects.first().api_last_seen
-        except AttributeError:
-            last_seen = None
-
         def format_last_seen(last_seen):
             if last_seen is None:
                 return "never"
 
             return last_seen.strftime("%Y-%m-%d %H:%M:%S")
 
-        context = {
-            "backends": [
-                {
-                    "name": "TPP",
-                    "last_seen": format_last_seen(last_seen),
-                    "queue": {
-                        "acked": acked,
-                        "unacked": unacked,
-                    },
-                    "show_warning": show_warning(unacked, last_seen),
+        def get_stats(backend):
+            acked = backend.job_requests.acked().count()
+            unacked = backend.job_requests.unacked().count()
+
+            try:
+                last_seen = (
+                    backend.stats.order_by("-api_last_seen").first().api_last_seen
+                )
+            except AttributeError:
+                last_seen = None
+
+            return {
+                "name": backend.display_name,
+                "last_seen": format_last_seen(last_seen),
+                "queue": {
+                    "acked": acked,
+                    "unacked": unacked,
                 },
-            ],
-        }
+                "show_warning": show_warning(unacked, last_seen),
+            }
+
+        backends = Backend.objects.all()
+        context = {"backends": [get_stats(b) for b in backends]}
 
         return TemplateResponse(request, "status.html", context)
 
@@ -387,7 +389,6 @@ class WorkspaceLog(ListView):
 class WorkspaceUnarchive(View):
     def post(self, request, *args, **kwargs):
         workspace = get_object_or_404(Workspace, name=self.kwargs["name"])
-
         workspace.is_archived = False
         workspace.save()
 

--- a/tests/jobserver/test_context_processors.py
+++ b/tests/jobserver/test_context_processors.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from jobserver.context_processors import backend_warnings, nav
+from jobserver.models import Backend
 
 from ..factories import JobRequestFactory, StatsFactory, UserFactory
 
@@ -22,10 +23,12 @@ def test_backend_warnings_with_no_warnings(rf):
 
 @pytest.mark.django_db
 def test_backend_warnings_with_warnings(rf):
-    JobRequestFactory()
+    tpp = Backend.objects.get(name="tpp")
+
+    JobRequestFactory(backend=tpp)
 
     last_seen = timezone.now() - timedelta(minutes=10)
-    StatsFactory(api_last_seen=last_seen)
+    StatsFactory(backend=tpp, api_last_seen=last_seen)
 
     request = rf.get("/")
     output = backend_warnings(request)

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import pytest
 from django.urls import reverse
@@ -10,6 +10,7 @@ from ..factories import (
     BackendFactory,
     JobFactory,
     JobRequestFactory,
+    StatsFactory,
     UserFactory,
     WorkspaceFactory,
 )
@@ -348,6 +349,25 @@ def test_jobrequestqueryset_unacked():
     JobRequestFactory.create_batch(3)
 
     assert JobRequest.objects.unacked().count() == 3
+
+
+@pytest.mark.django_db
+def test_stats_str_with_last_seen(freezer):
+    tpp = Backend.objects.get(name="tpp")
+
+    last_seen = datetime(2020, 12, 25, 10, 11, 12, tzinfo=timezone.utc)
+    stats = StatsFactory(backend=tpp, api_last_seen=last_seen, url="/foo")
+
+    assert str(stats) == "tpp | 2020-12-25 10:11:12 | /foo"
+
+
+@pytest.mark.django_db
+def test_stats_str_without_last_seen(freezer):
+    tpp = Backend.objects.get(name="tpp")
+
+    stats = StatsFactory(backend=tpp, api_last_seen=None, url="")
+
+    assert str(stats) == "tpp | never | "
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
This updates the Stats page (and related backend warnings banners) to handle multiple backends.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/P8umzoYp/f847916f-f223-4b2f-9f75-5bc067473108.jpg?v=5da4085a568e13863e917308d1d133e3)

When a backend needs to show a warning:

![](https://p198.p4.n0.cdn.getcloudapp.com/items/d5uPko09/1fda51b8-a865-481b-ae1d-a1e0fce77c57.jpg?v=9072e7eb609b26bc11846128563db15d)

