### PR TITLE
Job & JobRequest UI Improvements

### DIFF
--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -32,7 +32,7 @@
   <div class="col-md-9 col-lg-6 offset-lg-2">
 
     <h2><code>{{ job.action }}</code></h2>
-    <p class="small muted">
+    <p class="small text-muted">
       ID: {{ job.identifier }}
     </p>
 

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -31,7 +31,10 @@
 
   <div class="col-lg-10">
 
-    <h2>Job {{ job.identifier }}</h2>
+    <h2><code>{{ job.action }}</code></h2>
+    <p class="small muted">
+      ID: {{ job.identifier }}
+    </p>
 
     <div class="mb-4">
       <h3>State</h3>
@@ -56,11 +59,6 @@
       <div>
         <strong>Backend:</strong>
         <code>{{ job.job_request.backend }}</code>
-      </div>
-
-      <div>
-        <strong>Action:</strong>
-        <code>{{ job.action }}</code>
       </div>
 
       <div>

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -29,7 +29,7 @@
 
 <div class="row">
 
-  <div class="col-lg-10">
+  <div class="col-md-9 col-lg-6 offset-lg-2">
 
     <h2><code>{{ job.action }}</code></h2>
     <p class="small muted">
@@ -53,7 +53,7 @@
 
     </div>
 
-    <div class="mb-5">
+    <div class="mb-4">
       <h3>Config</h3>
 
       <div>
@@ -80,7 +80,7 @@
 
     </div>
 
-    <div class="mb-5">
+    <div class="mb-4">
       <h3>Timings</h3>
 
       <div>
@@ -111,7 +111,7 @@
 
   </div>
 
-  <div class="col-lg-2">
+  <div class="col-md-3 col-lg-2">
 
     <h3 class="text-center">Tools</h3>
 

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% load humanize %}
+{% load runtime %}
 
 {% block content %}
 
@@ -103,6 +104,10 @@
         <span title="{{ job.completed_at|default_if_none:"" }}">
           {{ job.completed_at|naturaltime|default_if_none:"-"}}
         </span>
+      </div>
+
+      <div>
+        <strong>Runtime:</strong> <span>{% runtime job.runtime %}</span>
       </div>
     </div>
 

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -3,6 +3,29 @@
 {% load humanize %}
 
 {% block content %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+
+    <li class="breadcrumb-item"><a href="/">Home</a></li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ job.job_request.workspace.get_absolute_url }}">
+        {{ job.job_request.workspace.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ job.job_request.get_absolute_url }}">
+        Request {{ job.job_request.id }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item active" aria-current="page">{{ job.action }}</li>
+
+  </ol>
+</nav>
+
 <div class="row">
 
   <div class="col-lg-10">

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -28,60 +28,83 @@
 
     <h2>Job Request: {{ jobrequest.pk }}</h2>
 
-    <ul class="list-unstyled ml-10">
-      <li class="pt-2">
+    <div class="mb-4">
+      <h3>State</h3>
+      <small>State is inferred from the related Jobs</small>
+
+      <div>
+        <strong>Status:</strong>
+        <code>{{ jobrequest.status }}</code>
+      </div>
+    </div>
+
+    <div class="mb-4">
+      <h3>Config</h3>
+
+      <div>
+        <strong>Backend:</strong>
+        <code>{{ jobrequest.backend }}</code>
+      </div>
+
+      <div>
         <strong>Workspace:</strong>
         <a href="{{ jobrequest.workspace.get_absolute_url }}">
           {{ jobrequest.workspace.name }}
         </a>
-        <small class="text-muted">
-          {% if jobrequest.workspace %}
-          ({{ jobrequest.workspace.repo_name }} | {{ jobrequest.workspace.branch }})
-          {% else %}
-          ({{ jobrequest.job_request.workspace.repo }} | {{ jobrequest.job_request.workspace.branch }})
-          {% endif %}
-        </small>
-      </li>
-      <li class="pt-2"><strong>Backend:</strong> {{ jobrequest.backend|default:"-" }}</li>
+        <small class="text-muted">({{ jobrequest.workspace.branch }})</small>
+      </div>
 
-      <li class="pt-2">
-        <strong>Requested Actions:</strong>
-        <ul>
-          {% for action in jobrequest.requested_actions %}
-          <li>{{ action }}</li>
-          {% endfor %}
-        </ul>
-      </li>
+      <div>
+        <strong>Force run dependencies?:</strong>
+        {{ jobrequest.force_run_dependencies }}
+      </div>
 
-      <li class="pt-2"><strong>Force run dependencies?:</strong> {{ jobrequest.force_run_dependencies }}</li>
-
-      <li class="pt-2">
+      <div>
         <strong>SHA:</strong>
         <a href="{{ jobrequest.workspace.get_sha_url }}">
           {{ jobrequest.sha|slice:7|default:"-" }}
         </a>
-      </li>
-    </ul>
+      </div>
 
-    <hr />
+      <div>
+        <strong>Requested Actions:</strong>
+        <ul>
+          {% for action in jobrequest.requested_actions %}
+          <li><code>{{ action }}</code></li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
 
-    <h4>Timings</h4>
-    <ul class="list-unstyled">
-      <li class="pt-2"><strong>Created:</strong> {{ jobrequest.created_at|naturaltime }}</li>
-      <li class="pt-2"><strong>Started:</strong> {{ jobrequest.started_at|naturaltime|default_if_none:"-" }}</li>
-      <li class="pt-2"><strong>Finished:</strong> {{ jobrequest.completed_at|naturaltime|default_if_none:"-"}}</li>
-      <li class="pt-2"><strong>Runtime:</strong> <span>{% runtime jobrequest.runtime %}</span></li>
-    </ul>
+    <div class="mb-4">
+      <h3>Timings</h3>
 
-    <hr />
+      <div>
+        <strong>Created:</strong>
+        <span title="{{ jobrequest.created_at|date:"Y-m-d H:i:s" }}">
+          {{ jobrequest.created_at|naturaltime }}
+        </span>
+      </div>
 
-    <h4>State</h4>
-    <small>State is inferred from the related Jobs</small>
-    <ul class="list-unstyled">
-      <li class="pt-2"><strong>Status:</strong> {{ jobrequest.status }}</li>
-      <li class="pt-2"><strong>Status Code:</strong> {{ jobrequest.status_code|default:"-" }}</li>
-      <li class="pt-2"><strong>Status Message:</strong> {{ jobrequest.status_message|default:"-" }}</li>
-    </ul>
+      <div>
+        <strong>Started:</strong>
+        <span title="{{ jobrequest.started_at|default_if_none:"" }}">
+          {{ jobrequest.started_at|naturaltime|default_if_none:"-" }}
+        </span>
+      </div>
+
+      <div>
+        <strong>Finished:</strong>
+        <span title="{{ jobrequest.completed_at|default_if_none:"" }}">
+          {{ jobrequest.completed_at|naturaltime|default_if_none:"-"}}
+        </span>
+      </div>
+
+      <div>
+        <strong>Runtime:</strong>
+        <span>{% runtime jobrequest.runtime %}</span>
+      </div>
+    </div>
   </div>
 
   <div class="col-md-3 col-lg-2">

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -24,9 +24,9 @@
 </nav>
 
 <div class="row mb-3">
-  <div class="col-md-9 col-lg-10">
+  <div class="col-md-9 col-lg-6 offset-lg-2">
 
-    <h3>Job Request: {{ jobrequest.pk }}</h3>
+    <h2>Job Request: {{ jobrequest.pk }}</h2>
 
     <ul class="list-unstyled ml-10">
       <li class="pt-2">
@@ -114,27 +114,31 @@
 
 </div>
 
-<hr />
+<div class="row mb-3">
+  <div class="col-md-9 col-lg-8 offset-lg-2">
 
-<h4>Jobs</h4>
-<table class="table">
-  <thead>
-    <tr>
-      <th>ID</th>
-      <th>Status</th>
-      <th>Action</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for job in jobrequest.jobs.all %}
-    <tr>
-      <td>{{ job.identifier }}</td>
-      <td>{{ job.status }}</td>
-      <td>{{ job.action }}</td>
-      <td><a class="btn btn-sm btn-secondary" href="{{ job.get_absolute_url }}">View</a></td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
-{% endblock content %}
+    <h4>Jobs</h4>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Status</th>
+          <th>Action</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for job in jobrequest.jobs.all %}
+        <tr>
+          <td>{{ job.identifier }}</td>
+          <td>{{ job.status }}</td>
+          <td>{{ job.action }}</td>
+          <td><a class="btn btn-sm btn-secondary" href="{{ job.get_absolute_url }}">View</a></td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% endblock content %}
+
+  </div>
+</div>

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% load humanize %}
+{% load runtime %}
 
 {% block content %}
 
@@ -69,6 +70,7 @@
       <li class="pt-2"><strong>Created:</strong> {{ jobrequest.created_at|naturaltime }}</li>
       <li class="pt-2"><strong>Started:</strong> {{ jobrequest.started_at|naturaltime|default_if_none:"-" }}</li>
       <li class="pt-2"><strong>Finished:</strong> {{ jobrequest.completed_at|naturaltime|default_if_none:"-"}}</li>
+      <li class="pt-2"><strong>Runtime:</strong> <span>{% runtime jobrequest.runtime %}</span></li>
     </ul>
 
     <hr />

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -3,6 +3,25 @@
 {% load humanize %}
 
 {% block content %}
+
+<nav aria-label="breadcrumb">
+  <ol class="breadcrumb">
+
+    <li class="breadcrumb-item"><a href="/">Home</a></li>
+
+    <li class="breadcrumb-item">
+      <a href="{{ jobrequest.workspace.get_absolute_url }}">
+        {{ jobrequest.workspace.name }}
+      </a>
+    </li>
+
+    <li class="breadcrumb-item active" aria-current="page">
+      Request {{ job.job_request.id }}
+    </li>
+
+  </ol>
+</nav>
+
 <div class="row mb-3">
   <div class="col-md-9 col-lg-10">
 


### PR DESCRIPTION
This tries to improve the Job & JobRequest detail pages in terms of answering "where am I".  This was born from a researcher sending us links to both pages and it not being clear where in the app one had landed.

Of particular note, I've added breadcrumbs to both pages and promoted the action of a Job to be its title.

**Job Request Detail**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/5zudq0yk/0aa1c590-69ec-467f-a16f-9166d83b52db.jpg?v=79a469f2f775685fa2a75e3ef6743798)

**Job Detail**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/jkuYk9lA/7672f2b8-7be0-43a4-8b7f-3a87a85ed32d.jpg?v=a2a2a7aef5a6d8dcdcb8e5219a25ab6c)