### PR TITLE
Improve Workspace's Toggle Views

### DIFF
--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -36,6 +36,10 @@ class SettingsForm(forms.ModelForm):
         model = User
 
 
+class WorkspaceArchiveToggleForm(forms.Form):
+    is_archived = forms.BooleanField(required=False)
+
+
 class WorkspaceCreateForm(forms.ModelForm):
     branch = forms.CharField(widget=forms.Select)
 

--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -86,3 +86,7 @@ class WorkspaceCreateForm(forms.ModelForm):
         name = self.cleaned_data["name"]
 
         return name.lower()
+
+
+class WorkspaceNotificationsToggleForm(forms.Form):
+    will_notify = forms.BooleanField(required=False)

--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -334,17 +334,14 @@ class Workspace(models.Model):
     def get_absolute_url(self):
         return reverse("workspace-detail", kwargs={"name": self.name})
 
-    def get_archive_url(self):
-        return reverse("workspace-archive", kwargs={"name": self.name})
+    def get_archive_toggle_url(self):
+        return reverse("workspace-archive-toggle", kwargs={"name": self.name})
 
     def get_notifications_toggle_url(self):
         return reverse("workspace-notifications-toggle", kwargs={"name": self.name})
 
     def get_statuses_url(self):
         return reverse("workspace-statuses", kwargs={"name": self.name})
-
-    def get_unarchive_url(self):
-        return reverse("workspace-unarchive", kwargs={"name": self.name})
 
     def get_action_status_lut(self):
         """

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -64,15 +64,10 @@
 
         <div class="col-lg-3 text-right">
           {% if request.user.is_authenticated %}
-          <form
-            method="POST"
-            {% if not workspace.is_archived %}
-            action="{{ workspace.get_archive_url }}"
-            {% else %}
-            action="{{ workspace.get_unarchive_url }}"
-            {% endif %}
-            class="my-2">
+          <form method="POST" action="{{ workspace.get_archive_toggle_url }}" class="my-2">
             {% csrf_token %}
+
+            <input type="hidden" name="is_archived" value="{{ workspace.is_archived|yesno:",True" }}" />
 
             <button class="btn btn-danger" type="submit">
               {% if not workspace.is_archived %}

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -85,6 +85,9 @@
 
           <form method="POST" class="mb-2" action="{{ workspace.get_notifications_toggle_url }}">
             {% csrf_token %}
+
+            <input type="hidden" name="will_notify" value="{{ workspace.will_notify|yesno:",True" }}" />
+
             <button class="btn btn-success" type="submit">
               Turn Notifications {% if workspace.will_notify %}Off{% else %}On{% endif %}
             </button>

--- a/jobserver/urls.py
+++ b/jobserver/urls.py
@@ -31,12 +31,11 @@ from .views import (
     JobZombify,
     Settings,
     Status,
-    WorkspaceArchive,
+    WorkspaceArchiveToggle,
     WorkspaceCreate,
     WorkspaceDetail,
     WorkspaceLog,
     WorkspaceNotificationsToggle,
-    WorkspaceUnarchive,
 )
 
 
@@ -73,12 +72,15 @@ urlpatterns = [
     path("workspaces/new/", WorkspaceCreate.as_view(), name="workspace-create"),
     path("__debug__/", include(debug_toolbar.urls)),
     path("<name>/", WorkspaceDetail.as_view(), name="workspace-detail"),
-    path("<name>/archive/", WorkspaceArchive.as_view(), name="workspace-archive"),
+    path(
+        "<name>/archive-toggle/",
+        WorkspaceArchiveToggle.as_view(),
+        name="workspace-archive-toggle",
+    ),
     path("<name>/logs/", WorkspaceLog.as_view(), name="workspace-logs"),
     path(
         "<name>/notifications-toggle/",
         WorkspaceNotificationsToggle.as_view(),
         name="workspace-notifications-toggle",
     ),
-    path("<name>/unarchive/", WorkspaceUnarchive.as_view(), name="workspace-unarchive"),
 ]

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -21,6 +21,7 @@ from .backends import show_warning
 from .forms import (
     JobRequestCreateForm,
     SettingsForm,
+    WorkspaceArchiveToggleForm,
     WorkspaceCreateForm,
     WorkspaceNotificationsToggleForm,
 )
@@ -243,11 +244,14 @@ class Status(View):
 
 
 @method_decorator(login_required, name="dispatch")
-class WorkspaceArchive(View):
+class WorkspaceArchiveToggle(View):
     def post(self, request, *args, **kwargs):
         workspace = get_object_or_404(Workspace, name=self.kwargs["name"])
 
-        workspace.is_archived = True
+        form = WorkspaceArchiveToggleForm(request.POST)
+        form.is_valid()
+
+        workspace.is_archived = form.cleaned_data["is_archived"]
         workspace.save()
 
         return redirect("/")
@@ -428,13 +432,3 @@ class WorkspaceNotificationsToggle(View):
         workspace.save()
 
         return redirect(workspace)
-
-
-@method_decorator(login_required, name="dispatch")
-class WorkspaceUnarchive(View):
-    def post(self, request, *args, **kwargs):
-        workspace = get_object_or_404(Workspace, name=self.kwargs["name"])
-        workspace.is_archived = False
-        workspace.save()
-
-        return redirect("/")

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -18,7 +18,12 @@ from django.views.generic import (
 )
 
 from .backends import show_warning
-from .forms import JobRequestCreateForm, SettingsForm, WorkspaceCreateForm
+from .forms import (
+    JobRequestCreateForm,
+    SettingsForm,
+    WorkspaceCreateForm,
+    WorkspaceNotificationsToggleForm,
+)
 from .github import get_branch_sha, get_repos_with_branches
 from .models import Backend, Job, JobRequest, User, Workspace
 from .project import get_actions
@@ -416,7 +421,10 @@ class WorkspaceNotificationsToggle(View):
     def post(self, request, *args, **kwargs):
         workspace = get_object_or_404(Workspace, name=self.kwargs["name"])
 
-        workspace.will_notify = not workspace.will_notify
+        form = WorkspaceNotificationsToggleForm(data=request.POST)
+        form.is_valid()
+
+        workspace.will_notify = form.cleaned_data["will_notify"]
         workspace.save()
 
         return redirect(workspace)

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -394,12 +394,12 @@ def test_workspace_get_absolute_url():
 
 
 @pytest.mark.django_db
-def test_workspace_get_archive_url():
+def test_workspace_get_archive_toggle_url():
     workspace = WorkspaceFactory()
 
-    url = workspace.get_archive_url()
+    url = workspace.get_archive_toggle_url()
 
-    assert url == reverse("workspace-archive", kwargs={"name": workspace.name})
+    assert url == reverse("workspace-archive-toggle", kwargs={"name": workspace.name})
 
 
 @pytest.mark.django_db
@@ -418,15 +418,6 @@ def test_workspace_get_statuses_url():
     workspace = WorkspaceFactory()
     url = workspace.get_statuses_url()
     assert url == reverse("workspace-statuses", kwargs={"name": workspace.name})
-
-
-@pytest.mark.django_db
-def test_workspace_get_unarchive_url():
-    workspace = WorkspaceFactory()
-
-    url = workspace.get_unarchive_url()
-
-    assert url == reverse("workspace-unarchive", kwargs={"name": workspace.name})
 
 
 @pytest.mark.django_db

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -763,7 +763,7 @@ def test_workspacelog_unknown_workspace(rf):
 @pytest.mark.django_db
 def test_workspacenotificationstoggle_success(rf):
     workspace = WorkspaceFactory(will_notify=True)
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post(MEANINGLESS_URL, {"will_notify": ""})
     request.user = UserFactory()
 
     response = WorkspaceNotificationsToggle.as_view()(request, name=workspace.name)

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -21,12 +21,11 @@ from jobserver.views import (
     JobZombify,
     Settings,
     Status,
-    WorkspaceArchive,
+    WorkspaceArchiveToggle,
     WorkspaceCreate,
     WorkspaceDetail,
     WorkspaceLog,
     WorkspaceNotificationsToggle,
-    WorkspaceUnarchive,
     superuser_required,
 )
 
@@ -507,29 +506,13 @@ def test_status_unhealthy(rf):
 
 
 @pytest.mark.django_db
-def test_workspacearchive_already_archived(rf):
-    workspace = WorkspaceFactory(is_archived=True)
-
-    request = rf.post(MEANINGLESS_URL)
-    request.user = UserFactory()
-
-    response = WorkspaceArchive.as_view()(request, name=workspace.name)
-
-    assert response.status_code == 302
-    assert response.url == "/"
-
-    workspace.refresh_from_db()
-    assert workspace.is_archived
-
-
-@pytest.mark.django_db
-def test_workspacearchive_success(rf):
+def test_workspacearchivetoggle_success(rf):
     workspace = WorkspaceFactory(is_archived=False)
 
-    request = rf.post(MEANINGLESS_URL)
+    request = rf.post(MEANINGLESS_URL, {"is_archived": "True"})
     request.user = UserFactory()
 
-    response = WorkspaceArchive.as_view()(request, name=workspace.name)
+    response = WorkspaceArchiveToggle.as_view()(request, name=workspace.name)
 
     assert response.status_code == 302
     assert response.url == "/"
@@ -783,33 +766,3 @@ def test_workspacenotificationstoggle_unknown_workspace(rf):
 
     with pytest.raises(Http404):
         WorkspaceNotificationsToggle.as_view()(request, name="test")
-
-
-@pytest.mark.django_db
-def test_workspaceunarchive_already_unarchived(rf):
-    workspace = WorkspaceFactory(is_archived=False)
-
-    request = rf.post(MEANINGLESS_URL)
-    request.user = UserFactory()
-
-    response = WorkspaceUnarchive.as_view()(request, name=workspace.name)
-
-    assert response.status_code == 302
-    assert response.url == "/"
-
-    workspace.refresh_from_db()
-    assert not workspace.is_archived
-
-
-@pytest.mark.django_db
-def test_workspaceunarchive_success(rf):
-    workspace = WorkspaceFactory(is_archived=True)
-
-    request = rf.post(MEANINGLESS_URL)
-    request.user = UserFactory()
-
-    response = WorkspaceUnarchive.as_view()(request, name=workspace.name)
-    assert response.status_code == 302
-    assert response.url == "/"
-    workspace.refresh_from_db()
-    assert not workspace.is_archived


### PR DESCRIPTION
This converts both the Archive and Notifications toggling view(s) to use hidden form inputs with the desired value.

There's no handling of or tests for an invalid form because I couldn't make one…  Any string value is considered truthy, while the lack of a value or the key is considered falsey.