### PR TITLE
Explain Notification Settings

### DIFF
--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -273,6 +273,24 @@
 
       </div>
 
+      <div class="mb-5">
+        <p>
+          Notifications for {{ workspace.name }} are:
+          <strong>{{ workspace.will_notify|yesno:"On,Off" }}</strong>
+
+          <br />
+
+          <small class="text-muted">
+            {% if workspace.will_notify %}
+            You will receive notifications for all Jobs created from this request to <code>{{ request.user.notifications_email }}</code>.
+            <br />
+            You can change this email address in your <a href="{% url 'settings' %}">settings</a>.
+            {% else %}
+            You can enable notifications for this workspace by clicking Details above.
+            {% endif %}
+          </small>
+      </div>
+
       <div class="form-group">
         <input type="submit" name="submit" value="Submit" class="btn btn-primary" id="submit-id-submit" />
       </div>


### PR DESCRIPTION
This exposes the current state of a Workspace's notification settings below the JobRequestCreate form and provides some explainer text for what that means when notifications are on or off.

**Notifications are on**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/6quxynyQ/b33b7a6f-464e-48b2-ab7c-47a4f155ec46.jpg?v=7e0a6dbe1f8af6ed984dfc6a31aae051)

**Notifications are off**
![](https://p198.p4.n0.cdn.getcloudapp.com/items/jkuY5kxm/42825d8f-03e5-4b61-a9a6-c36823e18c03.jpg?v=a35cc9329ad7e1a79fc44460e62f30ee)

Fixes #333 