### PR TITLE
Add Feedback when Saving Settings

### DIFF
--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -6,7 +6,6 @@ from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
-from django.urls import reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.generic import (
     CreateView,
@@ -202,7 +201,7 @@ class JobRequestZombify(View):
 class Settings(UpdateView):
     form_class = SettingsForm
     template_name = "settings.html"
-    success_url = reverse_lazy("settings")
+    success_url = "/"
 
     def form_valid(self, form):
         response = super().form_valid(form)

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -204,6 +204,13 @@ class Settings(UpdateView):
     template_name = "settings.html"
     success_url = reverse_lazy("settings")
 
+    def form_valid(self, form):
+        response = super().form_valid(form)
+
+        messages.success(self.request, "Settings saved successfully")
+
+        return response
+
     def get_object(self):
         return self.request.user
 

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -421,7 +421,7 @@ def test_settings_post(rf):
 
     response = Settings.as_view()(request)
     assert response.status_code == 302
-    assert response.url == reverse("settings")
+    assert response.url == "/"
 
     user2.refresh_from_db()
 


### PR DESCRIPTION
This some feedback to clicking the Save button on the Settings form so the user has some idea of whether their changes were actually saved.  It also redirects them to the homepage since there's only one setting so they probably don't need to stay there.

Fixes #329 