### PR TITLE
Refresh Job Instance Before Sending Emails

### DIFF
--- a/jobserver/api.py
+++ b/jobserver/api.py
@@ -163,6 +163,7 @@ class JobAPIUpdate(APIView):
                 for key, value in job_data.items():
                     setattr(job, key, value)
                 job.save()
+                job.refresh_from_db()
 
                 if not job_request.workspace.will_notify:
                     # Workspace has notificaitons turned off


### PR DESCRIPTION
This refreshes the `job` variable to a Job instance as retrieved from the database.  Without this change the datetime fields (eg `started_at` and `completed_at`) used in calculating Runtime were strings as contained in the payload.

[Related Sentry issue](https://sentry.io/organizations/ebm-datalab/issues/2164587438/?project=5443358&query=is%3Aunresolved)