### PR TITLE
Add Job.updated_at to JobDetail

### DIFF
--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -92,14 +92,14 @@
 
       <div>
         <strong>Started:</strong>
-        <span title="{{ job.started_at|default_if_none:"" }}">
+        <span title="{{ job.started_at|date:"Y-m-d H:i:s"|default_if_none:"" }}">
           {{ job.started_at|naturaltime|default_if_none:"-" }}
         </span>
       </div>
 
       <div>
         <strong>Finished:</strong>
-        <span title="{{ job.completed_at|default_if_none:"" }}">
+        <span title="{{ job.completed_at|date:"Y-m-d H:i:s"|default_if_none:"" }}">
           {{ job.completed_at|naturaltime|default_if_none:"-"}}
         </span>
       </div>
@@ -110,7 +110,7 @@
 
       <div>
         <strong>Last Updated by Runner:</strong>
-        <span title="{{ job.updated_at|default_if_none:"" }}">
+        <span title="{{ job.updated_at|date:"Y-m-d H:i:s"|default_if_none:"" }}">
           {{ job.updated_at|naturaltime|default_if_none:"-" }}
         </span>
       </div>

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -107,6 +107,13 @@
       <div>
         <strong>Runtime:</strong> <span>{% runtime job.runtime %}</span>
       </div>
+
+      <div>
+        <strong>Last Updated by Runner:</strong>
+        <span title="{{ job.updated_at|default_if_none:"" }}">
+          {{ job.updated_at|naturaltime|default_if_none:"-" }}
+        </span>
+      </div>
     </div>
 
   </div>


### PR DESCRIPTION
This adds the updated_at timestamp to the JobDetail page.

Leaving warning text because I think it's going to be tied to the work for #332

Refs #344 