### PR TITLE
Fix Backend Warnings

### DIFF
--- a/jobserver/backends.py
+++ b/jobserver/backends.py
@@ -29,10 +29,7 @@ def get_configured_backends():
     return backends
 
 
-def show_warning(unacked, last_seen, minutes=5):
-    if unacked == 0:
-        return False
-
+def show_warning(last_seen, minutes=5):
     if last_seen is None:
         return False
 

--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -3,7 +3,7 @@ import functools
 from django.urls import reverse
 
 from .backends import show_warning
-from .models import Backend, Stats
+from .models import Backend
 
 
 def _is_active(request, prefix):
@@ -14,7 +14,9 @@ def backend_warnings(request):
     def iter_warnings(backends):
         for backend in backends:
             try:
-                last_seen = Stats.objects.first().api_last_seen
+                last_seen = (
+                    backend.stats.order_by("-api_last_seen").first().api_last_seen
+                )
             except AttributeError:
                 last_seen = None
 

--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -18,11 +18,9 @@ def backend_warnings(request):
                     backend.stats.order_by("-api_last_seen").first().api_last_seen
                 )
             except AttributeError:
-                last_seen = None
+                continue
 
-            unacked = backend.job_requests.unacked().count()
-
-            if show_warning(unacked, last_seen):
+            if show_warning(last_seen):
                 yield backend.display_name
 
     backends = Backend.objects.all()

--- a/jobserver/context_processors.py
+++ b/jobserver/context_processors.py
@@ -1,9 +1,13 @@
 import functools
 
+import structlog
 from django.urls import reverse
 
 from .backends import show_warning
 from .models import Backend
+
+
+logger = structlog.get_logger(__name__)
 
 
 def _is_active(request, prefix):
@@ -18,6 +22,7 @@ def backend_warnings(request):
                     backend.stats.order_by("-api_last_seen").first().api_last_seen
                 )
             except AttributeError:
+                logger.info(f"No stats found for backend '{backend.name}'")
                 continue
 
             if show_warning(last_seen):

--- a/jobserver/views.py
+++ b/jobserver/views.py
@@ -240,7 +240,7 @@ class Status(View):
                     "acked": acked,
                     "unacked": unacked,
                 },
-                "show_warning": show_warning(unacked, last_seen),
+                "show_warning": show_warning(last_seen),
             }
 
         backends = Backend.objects.all()

--- a/tests/jobserver/test_backends.py
+++ b/tests/jobserver/test_backends.py
@@ -34,24 +34,20 @@ def test_get_configured_backends_unknown_backend(monkeypatch):
         get_configured_backends()
 
 
-def test_show_warning_zero_unacked():
-    assert show_warning(0, True) is False
-
-
 def test_show_warning_last_seen_is_none():
-    assert show_warning(1, None) is False
+    assert show_warning(None) is False
 
 
 def test_show_warning_last_seen_equal_threhold(freezer):
     last_seen = timezone.now() - timedelta(minutes=3)
-    assert show_warning(1, last_seen, minutes=3) is True
+    assert show_warning(last_seen, minutes=3) is True
 
 
 def test_show_warning_last_seen_less_than_threhold(freezer):
     last_seen = timezone.now() - timedelta(minutes=2)
-    assert show_warning(1, last_seen, minutes=3) is False
+    assert show_warning(last_seen, minutes=3) is False
 
 
 def test_show_warning_success(freezer):
     last_seen = timezone.now() - timedelta(minutes=6)
-    assert show_warning(1, last_seen) is True
+    assert show_warning(last_seen) is True


### PR DESCRIPTION
This fixes a bug with how we look up stats (making it a per-backend lookup) and changes the warnings check to ignore unacked jobs.

Fixes #332 