### PR TITLE
Handle Wrong Org Logins

### DIFF
--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -204,7 +204,10 @@ class GithubOrganizationOAuth2(GithubOAuth2):
         # The member-of-an-org endpoint returns a 204 on success, any other
         # status code is a failure here.
         if r.status_code != 204:
-            msg = f"'{username}' is not part of the OpenSAFELY GitHub Organization."
+            msg = (
+                f'"{username}" is not part of the OpenSAFELY GitHub Organization. '
+                '<a href="https://opensafely.org/contact/">Contact us</a> to request access.'
+            )
             raise AuthFailed(self, msg)
 
         return user_data

--- a/jobserver/github.py
+++ b/jobserver/github.py
@@ -179,6 +179,7 @@ class GithubOrganizationOAuth2(GithubOAuth2):
         membership endpoint.
         """
         user_data = super().user_data(access_token, *args, **kwargs)
+        username = user_data.get("login")
 
         # https://docs.github.com/en/free-pro-team@latest/rest/reference/orgs#check-organization-membership-for-a-user
         f = furl(BASE_URL)
@@ -186,7 +187,7 @@ class GithubOrganizationOAuth2(GithubOAuth2):
             "orgs",
             "opensafely",
             "members",
-            user_data.get("login"),
+            username,
         ]
 
         # Use our "service-level" PAT instead of the User's OAuth token to
@@ -203,6 +204,7 @@ class GithubOrganizationOAuth2(GithubOAuth2):
         # The member-of-an-org endpoint returns a 204 on success, any other
         # status code is a failure here.
         if r.status_code != 204:
-            raise AuthFailed(self, "User doesn't belong to the organization")
+            msg = f"'{username}' is not part of the OpenSAFELY GitHub Organization."
+            raise AuthFailed(self, msg)
 
         return user_data

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -67,6 +67,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_structlog.middlewares.RequestMiddleware",
+    "social_django.middleware.SocialAuthExceptionMiddleware",
 ]
 
 ROOT_URLCONF = "jobserver.urls"
@@ -149,6 +150,7 @@ AUTHENTICATION_BACKENDS = [
 AUTH_USER_MODEL = "jobserver.User"
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "/"
+LOGIN_ERROR_URL = "/"
 LOGIN_URL = reverse_lazy("social:begin", kwargs={"backend": "github"})
 SOCIAL_AUTH_GITHUB_KEY = env.str("SOCIAL_AUTH_GITHUB_KEY", default=None)
 SOCIAL_AUTH_GITHUB_SECRET = env.str("SOCIAL_AUTH_GITHUB_SECRET", default=None)

--- a/jobserver/templates/base.html
+++ b/jobserver/templates/base.html
@@ -82,7 +82,7 @@
         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
-        {{ message }}
+        {{ message|safe }}
       </div>
       {% endfor %}
 

--- a/tests/jobserver/test_github.py
+++ b/tests/jobserver/test_github.py
@@ -163,7 +163,11 @@ def test_githuborganizationoauth2_user_data_302(dummy_backend):
     expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
     responses.add(responses.GET, url=expected_url, status=302)
 
-    with pytest.raises(AuthFailed, match="User doesn't belong to the organization"):
+    match = (
+        '"test-username" is not part of the OpenSAFELY GitHub Organization. '
+        '<a href="https://opensafely.org/contact/">Contact us</a> to request access.'
+    )
+    with pytest.raises(AuthFailed, match=match):
         dummy_backend.user_data("access-token")
 
 
@@ -172,5 +176,9 @@ def test_githuborganizationoauth2_user_data_404(dummy_backend):
     expected_url = "https://api.github.com/orgs/opensafely/members/test-username"
     responses.add(responses.GET, url=expected_url, status=404)
 
-    with pytest.raises(AuthFailed, match="User doesn't belong to the organization"):
+    match = (
+        '"test-username" is not part of the OpenSAFELY GitHub Organization. '
+        '<a href="https://opensafely.org/contact/">Contact us</a> to request access.'
+    )
+    with pytest.raises(AuthFailed, match=match):
         dummy_backend.user_data("access-token")


### PR DESCRIPTION
This uses the Social Django middleware to redirect Users to the homepage and explain why they haven't been logged in.  It links to the OpenSAFELY contact page so they can hopefully get in contact with us.

Fixes #331 