### PR TITLE
Admin-Only Backend Selector

### DIFF
--- a/jobserver/backends.py
+++ b/jobserver/backends.py
@@ -14,6 +14,10 @@ available_backends = {
 }
 
 
+def backends_to_choices(backends):
+    return [(b.name, b.display_name) for b in backends]
+
+
 def get_configured_backends():
     """Get a list of configured Backends from the env"""
     backends = env.list("BACKENDS", default=[])

--- a/jobserver/forms.py
+++ b/jobserver/forms.py
@@ -12,7 +12,7 @@ class JobRequestCreateForm(forms.ModelForm):
         ]
         model = JobRequest
 
-    def __init__(self, actions, *args, **kwargs):
+    def __init__(self, actions, *args, backends=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.add_input(Submit("submit", "Submit"))
@@ -26,6 +26,11 @@ class JobRequestCreateForm(forms.ModelForm):
                 "required": "Please select at least one of the Actions listed above."
             },
         )
+
+        if backends:
+            self.fields["backend"] = forms.ChoiceField(
+                choices=backends, widget=forms.RadioSelect
+            )
 
 
 class SettingsForm(forms.ModelForm):

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -127,7 +127,7 @@
 {% endif %}
 
 {% if actions %}
-<div class="row job-create">
+<div class="row job-create mt-3">
   <div class="col-lg-8 offset-lg-2">
 
     <form method="POST">
@@ -141,7 +141,26 @@
       </ul>
       {% endif %}
 
+      {% if request.user.is_superuser %}
+      <p>Pick a backend to run your Jobs in:</p>
+
       <div class="form-group">
+
+        {% for value, label in form.backend.field.choices %}
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="radio"
+            name="backend"
+            id="id_backend1"
+            value="{{ value }}"
+            {% if form.backend.value == value %}checked{% endif %}
+            />
+          <label class="form-check-label" for="id_backend1">
+            {{ label }}
+          </label>
+        </div>
+        {% endfor %}
 
         {% if form.backend.errors %}
         <ul class="pl-3 mb-1">
@@ -152,6 +171,7 @@
         {% endif %}
 
       </div>
+      {% endif %}
 
       <p>Pick one or more actions to run:</p>
 

--- a/tests/jobserver/test_backends.py
+++ b/tests/jobserver/test_backends.py
@@ -3,7 +3,24 @@ from datetime import timedelta
 import pytest
 from django.utils import timezone
 
-from jobserver.backends import get_configured_backends, show_warning
+from jobserver.backends import (
+    backends_to_choices,
+    get_configured_backends,
+    show_warning,
+)
+
+from ..factories import BackendFactory
+
+
+@pytest.mark.django_db
+def test_backends_to_choices():
+    b1 = BackendFactory(name="test1", display_name="Display One")
+    b2 = BackendFactory(name="test2", display_name="Display Two")
+
+    choices = backends_to_choices([b1, b2])
+
+    assert choices[0] == ("test1", "Display One")
+    assert choices[1] == ("test2", "Display Two")
 
 
 def test_get_configured_backends_empty(monkeypatch):

--- a/tests/jobserver/test_forms.py
+++ b/tests/jobserver/test_forms.py
@@ -1,7 +1,18 @@
 import pytest
 from django.core.exceptions import ValidationError
 
-from jobserver.forms import WorkspaceCreateForm
+from jobserver.backends import backends_to_choices
+from jobserver.forms import JobRequestCreateForm, WorkspaceCreateForm
+from jobserver.models import Backend
+
+
+@pytest.mark.django_db
+def test_jobrequestcreateform_with_backends():
+    choices = backends_to_choices(Backend.objects.all())
+    form = JobRequestCreateForm([], backends=choices)
+
+    assert "backend" in form.fields
+    assert form.fields["backend"].choices == choices
 
 
 @pytest.mark.django_db

--- a/tests/jobserver/test_views.py
+++ b/tests/jobserver/test_views.py
@@ -675,6 +675,41 @@ def test_workspacedetail_post_success(rf, monkeypatch):
 
 
 @pytest.mark.django_db
+def test_workspacedetail_post_success_with_superuser(rf, monkeypatch):
+    monkeypatch.setenv("BACKENDS", "tpp,emis")
+
+    workspace = WorkspaceFactory()
+    user = UserFactory(is_superuser=True)
+
+    data = {
+        "backend": "emis",
+        "requested_actions": ["twiddle"],
+        "callback_url": "test",
+    }
+
+    # Build a RequestFactory instance
+    request = rf.post(MEANINGLESS_URL, data)
+    request.user = user
+
+    dummy_project = [{"name": "twiddle", "needs": []}]
+    with patch("jobserver.views.get_actions", new=lambda *args: dummy_project), patch(
+        "jobserver.views.get_branch_sha", new=lambda r, b: "abc123"
+    ):
+        response = WorkspaceDetail.as_view()(request, name=workspace.name)
+
+    assert response.status_code == 302, response.context_data["form"].errors
+    assert response.url == reverse("workspace-logs", kwargs={"name": workspace.name})
+
+    job_request = JobRequest.objects.first()
+    assert job_request.created_by == user
+    assert job_request.workspace == workspace
+    assert job_request.backend.name == "emis"
+    assert job_request.requested_actions == ["twiddle"]
+    assert job_request.sha == "abc123"
+    assert not job_request.jobs.exists()
+
+
+@pytest.mark.django_db
 def test_workspacedetail_unknown_workspace(rf):
     # Build a RequestFactory instance
     request = rf.get(MEANINGLESS_URL)


### PR DESCRIPTION
This reinstates the Backend selector on the JobRequestCreateForm, adapting it for our current Backends implementation.  The view and form are a little fiddly because of the superuser requirement, but that will all go away when we roll out backends to everyone and we can rely on a ModelForm field declaration instead.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/z8u4NzkA/4f977fa7-365e-442c-a905-9ee0b0e2bd6a.jpg?v=0bf27ebf7232df069da232762515642f)

Fixes #350 