### PR TITLE
Better Slack Previews

### DIFF
--- a/jobserver/templates/base.html
+++ b/jobserver/templates/base.html
@@ -7,6 +7,8 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
 
+    <meta property="og:site_name" content="OpenSAFELY Jobs" />
+
     {% block extra_meta %}{% endblock %}
 
     {% block styles %}

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -3,6 +3,13 @@
 {% load humanize %}
 {% load runtime %}
 
+{% block extra_meta %}
+<meta property="og:title" content="Action: {{ job.action }}" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="{{ request.build_absolute_uri }}" />
+<meta property="og:description" content="Workspace: {{ job.job_request.workspace.name }}" />
+{% endblock extra_meta %}
+
 {% block content %}
 
 <nav aria-label="breadcrumb">

--- a/jobserver/templates/job_request_detail.html
+++ b/jobserver/templates/job_request_detail.html
@@ -3,6 +3,13 @@
 {% load humanize %}
 {% load runtime %}
 
+{% block extra_meta %}
+<meta property="og:title" content="Requested Actions: {{ jobrequest.requested_actions|join:"," }}" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="{{ request.build_absolute_uri }}" />
+<meta property="og:description" content="Workspace: {{ jobrequest.workspace.name }}" />
+{% endblock extra_meta %}
+
 {% block content %}
 
 <nav aria-label="breadcrumb">

--- a/jobserver/templates/workspace_detail.html
+++ b/jobserver/templates/workspace_detail.html
@@ -4,6 +4,13 @@
 {% load runtime %}
 {% load static %}
 
+{% block extra_meta %}
+<meta property="og:title" content="{{ workspace.name }}" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="{{ request.build_absolute_uri }}" />
+<meta property="og:description" content="Repo: {{ workspace.repo_name }} ({{ workspace.branch }})" />
+{% endblock extra_meta %}
+
 {% block content %}
 
 {% if workspace.is_archived %}


### PR DESCRIPTION
This sets up Open Graph meta tags for the site and detail pages so we get rich previews in Slack.

![](https://p198.p4.n0.cdn.getcloudapp.com/items/llunBBYJ/6e0cfa3a-fa21-4a81-ab76-6c8a580507f6.jpg?v=b7c0b7285308e438e75afe6b911a6b2d)

Fixes #324 