### PR TITLE
Add Stale Data Warning

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -2,6 +2,7 @@ import base64
 import binascii
 import os
 import secrets
+from datetime import timedelta
 
 import structlog
 from django.contrib.auth.models import AbstractUser
@@ -117,6 +118,24 @@ class Job(models.Model):
 
     def get_zombify_url(self):
         return reverse("job-zombify", kwargs={"identifier": self.identifier})
+
+    @property
+    def is_missing_updates(self):
+        """
+        Is this Job missing expected updates from job-runner?
+
+        When a Job has yet to finish but we haven't had an update from
+        job-runner in >30 minutes we want to show users a warning.
+        """
+        if self.completed_at:
+            # Job has completed, ignore lack of updates
+            return False
+
+        now = timezone.now()
+        threshold = timedelta(minutes=30)
+        delta = now - self.updated_at
+
+        return delta > threshold
 
     @property
     def runtime(self):

--- a/jobserver/templates/job_detail.html
+++ b/jobserver/templates/job_detail.html
@@ -120,6 +120,16 @@
         <span title="{{ job.updated_at|date:"Y-m-d H:i:s"|default_if_none:"" }}">
           {{ job.updated_at|naturaltime|default_if_none:"-" }}
         </span>
+
+        {% if job.is_missing_updates %}
+        <div>
+          ⚠️
+          <small class="text-muted">
+            This Job has not been updated for over 30 minutes, some of the data
+            on this page could be stale.
+          </small>
+        </div>
+        {% endif %}
       </div>
     </div>
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,4 +1,8 @@
+from datetime import datetime
+
 import factory
+import factory.fuzzy
+from django.utils import timezone
 from pytz import utc
 from social_django.models import UserSocialAuth
 
@@ -19,6 +23,8 @@ class JobFactory(factory.django.DjangoModelFactory):
     job_request = factory.SubFactory("tests.factories.JobRequestFactory")
 
     identifier = factory.Sequence(lambda n: f"identifier-{n}")
+
+    updated_at = factory.fuzzy.FuzzyDateTime(datetime(2020, 1, 1, tzinfo=timezone.utc))
 
 
 class JobRequestFactory(factory.django.DjangoModelFactory):

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -85,6 +85,27 @@ def test_job_get_zombify_url():
 
 
 @pytest.mark.django_db
+def test_job_is_missing_updates_above_threshold():
+    last_update = timezone.now() - timedelta(minutes=50)
+    job = JobFactory(completed_at=None, updated_at=last_update)
+
+    assert job.is_missing_updates
+
+
+@pytest.mark.django_db
+def test_job_is_missing_updates_below_threshold():
+    last_update = timezone.now() - timedelta(minutes=29)
+    job = JobFactory(completed_at=None, updated_at=last_update)
+
+    assert not job.is_missing_updates
+
+
+@pytest.mark.django_db
+def test_job_is_missing_updates_completed():
+    assert not JobFactory(completed_at=timezone.now()).is_missing_updates
+
+
+@pytest.mark.django_db
 def test_job_runtime():
     duration = timedelta(hours=1, minutes=2, seconds=3)
     started_at = timezone.now() - duration


### PR DESCRIPTION


This adds a warning to the JobDetail page if the Job has yet to complete AND we haven't seen an update in >30 minutes.  I've phrased the warning to try and avoid specifically saying "this job has died" or "sync is busted".

![Image 2021-01-25 at 12 47 52 pm](https://user-images.githubusercontent.com/31017/105709137-3e567880-5f0d-11eb-9f14-98a4583bb1fa.jpg)

Fixes #344 