### PR TITLE
Be More Resilient Around Timestamps & State

### DIFF
--- a/jobserver/emails.py
+++ b/jobserver/emails.py
@@ -6,7 +6,7 @@ def send_finished_notification(email, job, job_url):
 
     context = {
         "action": job.action,
-        "elapsed_time": job.runtime.total_seconds,
+        "elapsed_time": job.runtime.total_seconds if job.runtime else None,
         "status": job.status,
         "status_message": job.status_message,
         "url": job_url,

--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -136,6 +136,10 @@ class Job(models.Model):
             # Job has completed, ignore lack of updates
             return False
 
+        if not self.updated_at:
+            # we can't check freshness without updated_at
+            return False
+
         now = timezone.now()
         threshold = timedelta(minutes=30)
         delta = now - self.updated_at
@@ -147,10 +151,7 @@ class Job(models.Model):
         if not self.is_finished:
             return
 
-        if self.started_at is None:
-            return
-
-        if self.completed_at is None:
+        if self.started_at is None or self.completed_at is None:
             return
 
         delta = self.completed_at - self.started_at

--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -121,6 +121,10 @@ class Job(models.Model):
         return reverse("job-zombify", kwargs={"identifier": self.identifier})
 
     @property
+    def is_finished(self):
+        return self.status in ["failed", "succeeded"]
+
+    @property
     def is_missing_updates(self):
         """
         Is this Job missing expected updates from job-runner?

--- a/jobserver/templates/emails/notify_finished.txt
+++ b/jobserver/templates/emails/notify_finished.txt
@@ -1,4 +1,4 @@
-{{ action }} in workspace {{ workspace }} {{ status }} after {{ elapsed_time }} seconds with the following message:
+{{ action }} in workspace {{ workspace }} {{ status }} {% if elapsed_time %} after {{ elapsed_time }} seconds {% endif %}with the following message:
 
 {{ status_message }}
 

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -101,15 +101,22 @@ def test_job_is_missing_updates_below_threshold():
 
 
 @pytest.mark.django_db
+def test_job_is_missing_updates_missing_updated_at():
+    assert not JobFactory(status="pending", updated_at=None).is_missing_updates
+
+
+@pytest.mark.django_db
 def test_job_is_missing_updates_completed():
-    assert not JobFactory(completed_at=timezone.now()).is_missing_updates
+    assert not JobFactory(status="failed").is_missing_updates
 
 
 @pytest.mark.django_db
 def test_job_runtime():
     duration = timedelta(hours=1, minutes=2, seconds=3)
     started_at = timezone.now() - duration
-    job = JobFactory(started_at=started_at, completed_at=timezone.now())
+    job = JobFactory(
+        status="succeeded", started_at=started_at, completed_at=timezone.now()
+    )
 
     assert job.runtime.hours == 1
     assert job.runtime.minutes == 2
@@ -118,7 +125,7 @@ def test_job_runtime():
 
 @pytest.mark.django_db
 def test_job_runtime_not_finished():
-    job = JobFactory(started_at=timezone.now())
+    job = JobFactory(status="running", started_at=timezone.now())
 
     # an unfinished job has no runtime
     assert job.runtime is None
@@ -126,7 +133,7 @@ def test_job_runtime_not_finished():
 
 @pytest.mark.django_db
 def test_job_runtime_not_started():
-    job = JobFactory()
+    job = JobFactory(status="pending")
 
     # an unstarted job has no runtime
     assert job.runtime is None
@@ -235,11 +242,13 @@ def test_jobrequest_runtime_not_finished(freezer):
 
     JobFactory(
         job_request=job_request,
+        status="succeeded",
         started_at=timezone.now() - timedelta(minutes=2),
         completed_at=timezone.now() - timedelta(minutes=1),
     )
     JobFactory(
         job_request=job_request,
+        status="running",
         started_at=timezone.now() - timedelta(seconds=30),
     )
 
@@ -257,8 +266,8 @@ def test_jobrequest_runtime_not_finished(freezer):
 def test_jobrequest_runtime_not_started():
     job_request = JobRequestFactory()
 
-    JobFactory(job_request=job_request)
-    JobFactory(job_request=job_request)
+    JobFactory(job_request=job_request, status="running")
+    JobFactory(job_request=job_request, status="pending")
 
     assert not job_request.runtime
 
@@ -271,11 +280,13 @@ def test_jobrequest_runtime_success():
 
     JobFactory(
         job_request=job_request,
+        status="succeeded",
         started_at=start,
         completed_at=start + timedelta(minutes=1),
     )
     JobFactory(
         job_request=job_request,
+        status="failed",
         started_at=start + timedelta(minutes=2),
         completed_at=start + timedelta(minutes=3),
     )

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -140,6 +140,13 @@ def test_job_runtime_not_started():
 
 
 @pytest.mark.django_db
+def test_job_runtime_without_timestamps():
+    job = JobFactory(status="succeeded", started_at=None, completed_at=None)
+
+    assert job.runtime is None
+
+
+@pytest.mark.django_db
 def test_job_str():
     job = JobFactory(action="Run")
 


### PR DESCRIPTION
This handles some timestamp related edgecases:
* Abstract the finished Job state (`failed` or `succeeded`) into a property
* Only look up Jobs via state (I _think_ I caught all of those)
* Add checks for timestamp fields when doing maths with them

We've agreed on:
* `created_at`: always set
* `updated_at`: always set
* `started_at`: mabye set
* `completed_at`: mabye set

However I've added the check on timestamps involved in maths to ensure we further edge cases don't 500 on us.