### PR TITLE
Configure Domain

### DIFF
--- a/jobserver/api.py
+++ b/jobserver/api.py
@@ -175,11 +175,9 @@ class JobAPIUpdate(APIView):
                     # already been there though)
                     continue
 
-                job_url = request.build_absolute_uri(job.get_absolute_url())
                 send_finished_notification(
                     job_request.created_by.notifications_email,
                     job,
-                    job_url,
                 )
                 log.info(
                     "Notified requesting user of finished job",

--- a/jobserver/emails.py
+++ b/jobserver/emails.py
@@ -1,7 +1,12 @@
+from django.conf import settings
+from furl import furl
 from incuna_mail import send
 
 
-def send_finished_notification(email, job, job_url):
+def send_finished_notification(email, job):
+    f = furl(settings.BASE_URL)
+    f.path = job.get_absolute_url()
+
     workspace_name = job.job_request.workspace.name
 
     context = {
@@ -9,7 +14,7 @@ def send_finished_notification(email, job, job_url):
         "elapsed_time": job.runtime.total_seconds if job.runtime else None,
         "status": job.status,
         "status_message": job.status_message,
-        "url": job_url,
+        "url": f.url,
         "workspace": workspace_name,
     }
 

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -15,6 +15,7 @@ import dj_database_url
 from django.contrib.messages import constants as messages
 from django.urls import reverse_lazy
 from environs import Env
+from furl import furl
 
 from services.logging import logging_config_dict
 from services.sentry import initialise_sentry
@@ -38,7 +39,7 @@ DEBUG = env.bool("DEBUG", default=False)
 
 BASE_URL = env.str("BASE_URL", default="http://localhost:8000")
 
-ALLOWED_HOSTS = ["*"]
+ALLOWED_HOSTS = [furl(BASE_URL).host]
 
 
 # Application definition

--- a/jobserver/settings.py
+++ b/jobserver/settings.py
@@ -36,6 +36,8 @@ SECRET_KEY = env.str("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DEBUG", default=False)
 
+BASE_URL = env.str("BASE_URL", default="http://localhost:8000")
+
 ALLOWED_HOSTS = ["*"]
 
 

--- a/tests/jobserver/test_emails.py
+++ b/tests/jobserver/test_emails.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 import pytest
+from django.conf import settings
 from django.utils import timezone
 
 from jobserver.emails import send_finished_notification
@@ -9,7 +10,7 @@ from ..factories import JobFactory, JobRequestFactory, WorkspaceFactory
 
 
 @pytest.mark.django_db
-def test_send_finished_notification(mailoutbox, rf):
+def test_send_finished_notification(mailoutbox):
     now = timezone.now()
 
     workspace = WorkspaceFactory(name="mailable-workspace")
@@ -23,10 +24,7 @@ def test_send_finished_notification(mailoutbox, rf):
         completed_at=now,
     )
 
-    request = rf.get("/")
-    url = request.build_absolute_uri(job.get_absolute_url)
-
-    send_finished_notification("test@example.com", job, url)
+    send_finished_notification("test@example.com", job)
 
     m = mailoutbox[0]
 
@@ -38,6 +36,7 @@ def test_send_finished_notification(mailoutbox, rf):
     assert job.status in m.body
     assert job.status_message in m.body
     assert str(job.runtime.total_seconds) in m.body
-    assert url in m.body
+    assert job.get_absolute_url() in m.body
+    assert settings.BASE_URL in m.body
 
     assert list(m.to) == ["test@example.com"]


### PR DESCRIPTION
This configures the sites domain via the env allowing us to decouple sending emails from the request and tighten up the `ALLOWED_HOSTS` setting.

Fixes #357 