### PR TITLE
Set JobRequest.completed_at when status is failed

### DIFF
--- a/jobserver/models.py
+++ b/jobserver/models.py
@@ -214,7 +214,7 @@ class JobRequest(models.Model):
         if not last_job:
             return
 
-        if not self.status == "succeeded":
+        if self.status not in ["failed", "succeeded"]:
             return
 
         return last_job.completed_at

--- a/tests/jobserver/test_models.py
+++ b/tests/jobserver/test_models.py
@@ -284,7 +284,7 @@ def test_jobrequest_runtime_one_job_missing_started_at(freezer):
     )
 
     assert job_request.started_at
-    assert not job_request.completed_at
+    assert job_request.completed_at
 
     # combined _finished_ Job runtime is 2 minutes because the second job
     # failed before it started


### PR DESCRIPTION
This changes `JobRequest.completled_at` to generate a timestamp when its status is `failed` or `succeeded` since we want to know about runtimes for failed Jobs too.  This mirrors how Jobs work.

Fixes #366 